### PR TITLE
dom_id should always be lowercase

### DIFF
--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -13,7 +13,7 @@ module CableReady
         [prefix, record.to_s.strip].compact.join("_")
       end
 
-      "##{id}".squeeze("#").strip
+      "##{id}".squeeze("#").strip.downcase
     end
   end
 end


### PR DESCRIPTION
I'm pretty sure that the output of the `dom_id` method should always be lower-cased. Right now, if you pass a constantized value like `User` it'll return `#User`. I don't think that's a thing... it might not be a rule, but it's certainly a convention.

Thoughts?