### PR TITLE
Support `to_dom_selector` for operation selectors

### DIFF
--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -5,7 +5,11 @@ module CableReady
     def dom_id(record, prefix = nil)
       prefix = prefix.to_s.strip if prefix
 
-      id = if record.is_a?(ActiveRecord::Relation)
+      id = if record.respond_to?(:to_dom_selector)
+        return record.to_dom_selector
+      elsif record.respond_to?(:to_dom_id)
+        record.to_dom_id
+      elsif record.is_a?(ActiveRecord::Relation)
         [prefix, record.model_name.plural].compact.join("_")
       elsif record.is_a?(ActiveRecord::Base)
         ActionView::RecordIdentifier.dom_id(record, prefix)
@@ -16,14 +20,11 @@ module CableReady
       "##{id}".squeeze("#").strip
     end
 
-    def determine_dom_selector(obj)
-      if obj.respond_to?(:to_dom_selector)
-        obj.to_dom_selector
-      elsif obj.is_a?(ActiveRecord::Base) || obj.is_a?(ActiveRecord::Relation)
-        dom_id(obj)
-      else
-        obj.to_s
-      end
+    def identifiable?(obj)
+      obj.respond_to?(:to_dom_selector) ||
+        obj.respond_to?(:to_dom_id) ||
+        obj.is_a?(ActiveRecord::Relation) ||
+        obj.is_a?(ActiveRecord::Base)
     end
   end
 end

--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -15,5 +15,15 @@ module CableReady
 
       "##{id}".squeeze("#").strip
     end
+
+    def determine_dom_selector(obj)
+      if obj.respond_to?(:to_dom_selector)
+        obj.to_dom_selector
+      elsif obj.is_a?(ActiveRecord::Base) || obj.is_a?(ActiveRecord::Relation)
+        dom_id(obj)
+      else
+        obj.to_s
+      end
+    end
   end
 end

--- a/lib/cable_ready/identifiable.rb
+++ b/lib/cable_ready/identifiable.rb
@@ -3,11 +3,11 @@
 module CableReady
   module Identifiable
     def dom_id(record, prefix = nil)
+      return record.to_dom_selector if record.respond_to?(:to_dom_selector)
+
       prefix = prefix.to_s.strip if prefix
 
-      id = if record.respond_to?(:to_dom_selector)
-        return record.to_dom_selector
-      elsif record.respond_to?(:to_dom_id)
+      id = if record.respond_to?(:to_dom_id)
         record.to_dom_id
       elsif record.is_a?(ActiveRecord::Relation)
         [prefix, record.model_name.plural].compact.join("_")

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -32,7 +32,7 @@ module CableReady
         options["selector"] = previous_selector if previous_selector && options.exclude?("selector")
         if options.include?("selector")
           @previous_selector = options["selector"]
-          options["selector"] = determine_dom_selector(previous_selector)
+          options["selector"] = identifiable?(previous_selector) ? dom_id(previous_selector) : previous_selector
         end
         @enqueued_operations[name.to_s] << options
         self

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -32,7 +32,7 @@ module CableReady
         options["selector"] = previous_selector if previous_selector && options.exclude?("selector")
         if options.include?("selector")
           @previous_selector = options["selector"]
-          options["selector"] = previous_selector.is_a?(ActiveRecord::Base) || previous_selector.is_a?(ActiveRecord::Relation) ? dom_id(previous_selector) : previous_selector
+          options["selector"] = determine_dom_selector(previous_selector)
         end
         @enqueued_operations[name.to_s] << options
         self

--- a/test/lib/cable_ready/cable_car_test.rb
+++ b/test/lib/cable_ready/cable_car_test.rb
@@ -25,4 +25,15 @@ class CableReady::CableCarTest < ActiveSupport::TestCase
     CableReady::CableCar.instance.inner_html(selector: "#users", html: "<span>winning</span>").dispatch(clear: false)
     assert_equal({"inner_html" => [{"selector" => "#users", "html" => "<span>winning</span>"}]}, CableReady::CableCar.instance.instance_variable_get(:@enqueued_operations))
   end
+
+  test "selectors should accept any object which respond_to? to_dom_selector" do
+    CableReady::CableCar.instance.reset!
+    my_object = Struct.new(:id) do
+      def to_dom_selector
+        "##{id}"
+      end
+    end.new("users")
+    dispatch = CableReady::CableCar.instance.inner_html(selector: my_object, html: "<span>winning</span>").dispatch
+    assert_equal({"innerHtml" => [{"selector" => "#users", "html" => "<span>winning</span>"}]}, dispatch)
+  end
 end

--- a/test/lib/cable_ready/cable_car_test.rb
+++ b/test/lib/cable_ready/cable_car_test.rb
@@ -30,7 +30,18 @@ class CableReady::CableCarTest < ActiveSupport::TestCase
     CableReady::CableCar.instance.reset!
     my_object = Struct.new(:id) do
       def to_dom_selector
-        "##{id}"
+        ".#{id}"
+      end
+    end.new("users")
+    dispatch = CableReady::CableCar.instance.inner_html(selector: my_object, html: "<span>winning</span>").dispatch
+    assert_equal({"innerHtml" => [{"selector" => ".users", "html" => "<span>winning</span>"}]}, dispatch)
+  end
+
+  test "selectors should accept any object which respond_to? to_dom_id" do
+    CableReady::CableCar.instance.reset!
+    my_object = Struct.new(:id) do
+      def to_dom_id
+        id
       end
     end.new("users")
     dispatch = CableReady::CableCar.instance.inner_html(selector: my_object, html: "<span>winning</span>").dispatch

--- a/test/lib/cable_ready/identifiable_test.rb
+++ b/test/lib/cable_ready/identifiable_test.rb
@@ -71,5 +71,7 @@ class CableReady::IdentifiableTest < ActiveSupport::TestCase
     assert_equal "#user_99", dom_id(user)
     assert_equal "#user_99", dom_id(user, nil)
     assert_equal "#all_active_user_99", dom_id(user, "all_active")
+
+    assert_equal "#user_99", determine_dom_selector(user)
   end
 end

--- a/test/lib/cable_ready/identifiable_test.rb
+++ b/test/lib/cable_ready/identifiable_test.rb
@@ -71,7 +71,5 @@ class CableReady::IdentifiableTest < ActiveSupport::TestCase
     assert_equal "#user_99", dom_id(user)
     assert_equal "#user_99", dom_id(user, nil)
     assert_equal "#all_active_user_99", dom_id(user, "all_active")
-
-    assert_equal "#user_99", determine_dom_selector(user)
   end
 end


### PR DESCRIPTION
Resolves #134 

FYI, I added `to_s` onto the final path for the updated selector logic, but that might be a breaking change (since previously a non-String object would be converted via `to_json`, not `to_s`). There's also the outstanding question of whether we need to issue a warning or exception if something mangled gets through like an inspect string with class name, etc.

Happy to work on updated docs as well, just let me know.