### PR TITLE
Smart options (they grow up so fast)

### DIFF
--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -24,8 +24,8 @@ module CableReady
     def add_operation_method(name)
       return if respond_to?(name)
       singleton_class.public_send :define_method, name, ->(*args) {
-        if args.one? && args.first.respond_to?(:to_cable) && args.first.to_cable.is_a?(Array)
-          selector, options = nil, args.first.to_cable
+        if args.one? && args.first.respond_to?(:to_operation) && args.first.to_operation.is_a?(Array)
+          selector, options = nil, args.first.to_operation
             .select { |e| e.is_a?(Symbol) && args.first.respond_to?("to_#{e}".to_sym) }
             .each_with_object({}) { |option, memo| memo[option.to_s] = args.first.send("to_#{option}".to_sym) }
         else

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -33,9 +33,7 @@ module CableReady
           selector, options = options, {} unless options.is_a?(Hash) # swap if only selector provided
           selector, options = args[0, 2] if args.many? # 2 or more params
           options.stringify_keys!
-          options.each do |key, value|
-            options[key] = value.send("to_#{key}".to_sym) if value.respond_to?("to_#{key}".to_sym)
-          end
+          options.each { |key, value| options[key] = value.send("to_#{key}".to_sym) if value.respond_to?("to_#{key}".to_sym) }
         end
         options["selector"] = selector if selector && options.exclude?("selector")
         options["selector"] = previous_selector if previous_selector && options.exclude?("selector")

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -28,6 +28,9 @@ module CableReady
         selector, options = options, {} unless options.is_a?(Hash) # swap if only selector provided
         selector, options = args[0, 2] if args.many? # 2 or more params
         options.stringify_keys!
+        options.each do |key, value|
+          options[key] = value.send("to_#{key}".to_sym) if value.respond_to?("to_#{key}".to_sym)
+        end
         options["selector"] = selector if selector && options.exclude?("selector")
         options["selector"] = previous_selector if previous_selector && options.exclude?("selector")
         if options.include?("selector")

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -32,8 +32,6 @@ module CableReady
               .each_with_object({}) { |option, memo| memo[option.to_s] = args.first.send("to_#{option}".to_sym) }
           when "Hash"
             selector, options = nil, args.first.to_operation_options
-              .select { |e| e.is_a?(Symbol) }
-              .each_with_object({}) { |option, memo| memo[option[0]] = option[1] }
           else
             raise TypeError, ":to_operation_options returned an #{args.first.to_operation_options.class.name}. Must be an Array or Hash."
           end

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -25,12 +25,12 @@ module CableReady
       return if respond_to?(name)
       singleton_class.public_send :define_method, name, ->(*args) {
         if args.one? && args.first.respond_to?(:to_operation_options) && [Array, Hash].include?(args.first.to_operation_options.class)
-          case args.first.to_operation_options.class.name
-          when "Array"
+          case args.first.to_operation_options
+          when Array
             selector, options = nil, args.first.to_operation_options
               .select { |e| e.is_a?(Symbol) && args.first.respond_to?("to_#{e}".to_sym) }
               .each_with_object({}) { |option, memo| memo[option.to_s] = args.first.send("to_#{option}".to_sym) }
-          when "Hash"
+          when Hash
             selector, options = nil, args.first.to_operation_options
           else
             raise TypeError, ":to_operation_options returned an #{args.first.to_operation_options.class.name}. Must be an Array or Hash."

--- a/test/lib/cable_ready/operation_builder_test.rb
+++ b/test/lib/cable_ready/operation_builder_test.rb
@@ -3,6 +3,20 @@
 require "test_helper"
 require_relative "../../../lib/cable_ready"
 
+class Death
+  def to_html
+    "I rock"
+  end
+
+  def to_dom_id
+    "death"
+  end
+
+  def to_cable
+    [:html, :dom_id, :spaz]
+  end
+end
+
 class CableReady::OperationBuilderTest < ActiveSupport::TestCase
   setup do
     @operation_builder = CableReady::OperationBuilder.new("test")
@@ -120,6 +134,51 @@ class CableReady::OperationBuilderTest < ActiveSupport::TestCase
       "innerHtml" => [
         {"html" => "<span>I rock</span>", "selector" => "#smelly"},
         {"html" => "<span>I rock too</span>", "selector" => "#smelly2"}
+      ]
+    }
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html option from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(html: death)
+
+    operations = {
+      "innerHtml" => [
+        {"html" => "I rock"}
+      ]
+    }
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html option with selector from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(death, html: death)
+
+    operations = {
+      "innerHtml" => [
+        {"html" => "I rock", "selector" => "#death"}
+      ]
+    }
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html and dom_id options from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(death)
+
+    operations = {
+      "innerHtml" => [
+        {"html" => "I rock", "domId" => "death"}
       ]
     }
 

--- a/test/lib/cable_ready/operation_builder_test.rb
+++ b/test/lib/cable_ready/operation_builder_test.rb
@@ -12,7 +12,7 @@ class Death
     "death"
   end
 
-  def to_cable
+  def to_operation
     [:html, :dom_id, :spaz]
   end
 end

--- a/test/lib/cable_ready/operation_builder_test.rb
+++ b/test/lib/cable_ready/operation_builder_test.rb
@@ -12,8 +12,17 @@ class Death
     "death"
   end
 
-  def to_operation
+  def to_operation_options
     [:html, :dom_id, :spaz]
+  end
+end
+
+class Life
+  def to_operation_options
+    {
+      html: "You go, girl",
+      dom_id: "life"
+    }
   end
 end
 
@@ -179,6 +188,21 @@ class CableReady::OperationBuilderTest < ActiveSupport::TestCase
     operations = {
       "innerHtml" => [
         {"html" => "I rock", "domId" => "death"}
+      ]
+    }
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html and dom_id options from Life object" do
+    @operation_builder.add_operation_method("inner_html")
+    life = Life.new
+
+    @operation_builder.inner_html(life)
+
+    operations = {
+      "innerHtml" => [
+        {"html" => "You go, girl", "domId" => "life"}
       ]
     }
 


### PR DESCRIPTION
This was inspired by conversations with @rrosen and @jaredcwhite. Rafe talked about how when he came to Ruby, he was inspired by the idea that objects should "just know what to do". And Jared's recent #135 was - at its core - about making it possible for an object to take responsibility for its DOM selector. This PR is hopefully the natural conclusion of both thoughts.

# An object should be able to provide its own options

Allows objects that conform to the `to_xxx` naming convention optionally provide a value to matching options.

```rb
class Death
  def to_html
    "I rock"
  end
end
```
```rb
death = Death.new
cable_car.inner_html(html: death) # => "innerHtml" => [{"html" => "I rock"}]
```

# An object can provide options and a selector

```rb
class Death
  def to_html
    "I rock"
  end

  def to_dom_id
    "death"
  end
end
```
```rb
death = Death.new
cable_car.inner_html(death, html: death) # => "innerHtml" => [{"html" => "I rock", "selector" => "#death"}]
```

# An object should be able to provide all options

If an object is the only parameter passed to an operation, **and** that object exposes a `to_operation_options` method, **and** the `to_operation` method returns an array of Symbols... the operation builder will build an options hash based for each matching `to_xxx` method that is defined.

```rb
class Death
  def to_html
    "I rock"
  end

  def to_dom_id
    "death"
  end

  def to_operation_options
    [:html, :dom_id, :spaz]
  end
end
```
```rb
death = Death.new
cable_car.inner_html(death) # => "innerHtml" => [{"html" => "I rock", "dom_id" => "death"}]
```
In the above case, `dom_id` is added to the options but doesn't get used as the `selector` because there would have to be a method on the class called `to_selector`. This is intentional because it means a class can be passed to an operation as a selector with other options, and have its `to_dom_id` method provide a `selector` value... **or** it can be the only parameter and provide a list of options to include which may or may not include `selector`. This ensures full flexibility in how the feature is used.

You can also return a Hash of options from `to_operation_options`:

```rb
class Life
  def to_operation_options
    {
      html: "You go, girl",
      dom_id: "life"
    }
  end
end
```
```rb
life = Life.new
cable_car.inner_html(life) # => "innerHtml" => [{"html" => "You go, girl", "dom_id" => "life"}]
```