### PR TITLE
register a CableReady JSON MIME type

### DIFF
--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -32,6 +32,8 @@ module CableReady
         ActionController::Renderers.add :operations do |operations, options|
           render json: operations.dispatch
         end
+
+        Mime::Type.register "application/vnd.cable-ready.json", :cable_ready
       end
     end
   end

--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -30,6 +30,7 @@ module CableReady
     initializer "renderer" do
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :operations do |operations, options|
+          response.content_type ||= Mime[:cable_ready]
           render json: operations.dispatch
         end
 


### PR DESCRIPTION
Based on conversations I was having with @leastbad yesterday, it sounds like establishing a dedicated MIME type for CableReady JSON responses delivered via cable_car could have a lot of benefits.  This PR registers the `application/vnd.cable-ready.json` MIME type as a `cable_ready` format within rails.

Generally speaking, it facilitates architecture patterns I've seen @hopsoft advocating of using one controller to deliver multiple formats.  A dedicated content type will allow the same controller action to serve both cable_ready or traditional JSON API requests:
```ruby
respond_to do |format|
  format.cable_ready { render operations: cable_car ... }
  format.json
```

More specifically, registering this content type within the cable_ready gem will facilitate some changes I'm proposing to the mrujs cable car plugin to have it use MIME type as the signal of whether to run CableReady operations.  [See the PR for more details](https://github.com/ParamagicDev/mrujs/pull/64).

Finally, if you want to see how all this stuff fits together, I've [wired up a cablecar-based modal library I'm working on to use the MIME-type based cablecar mrujs plugin](https://github.com/existentialmutt/cable_modal_poc/tree/mrujs_cablecar_plugin_pr_tests).  Making these changes allows that code to focus on it's own domain and offload all operation fetching and processing to the mrujs cablecar plugin and CableReady's operation serializer.

### Edit

In response to [some feedback](https://github.com/ParamagicDev/mrujs/pull/64) from @leastbad I've added a modification to `render operations:` to have it send the new content type by default.