### PR TITLE
redirect_to operation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -324,6 +324,18 @@ export default {
     after(window, callee, operation)
   },
 
+  redirectTo: (operation, callee) => {
+    before(window, callee, operation)
+    operate(operation, () => {
+      let { url, action } = operation
+      action = action || 'advance'
+      if (window.Turbo) window.Turbo.visit(url, { action })
+      if (window.Turbolinks) window.Turbolinks.visit(url, { action })
+      if (!window.Turbo && !window.Turbolinks) window.location.href = url
+    })
+    after(window, callee, operation)
+  },
+
   removeStorageItem: (operation, callee) => {
     before(document, callee, operation)
     operate(operation, () => {

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -54,6 +54,7 @@ module CableReady
         outer_html
         prepend
         push_state
+        redirect_to
         remove
         remove_attribute
         remove_css_class


### PR DESCRIPTION
Will test for `window.Turbo` and `window.Turbolinks` before falling back on `window.location.href`

[`action` option](https://github.com/turbolinks/turbolinks#turbolinksvisit) is supported, defaults to `advance`