### PR TITLE
Fix wrong CableReady import

### DIFF
--- a/javascript/stream_from_element.js
+++ b/javascript/stream_from_element.js
@@ -1,4 +1,4 @@
-import CableReady from 'cable_ready'
+import { perform } from './cable_ready'
 import { consumer } from './action_cable'
 
 class StreamFromElement extends HTMLElement {
@@ -12,7 +12,7 @@ class StreamFromElement extends HTMLElement {
         },
         {
           received (data) {
-            if (data.cableReady) CableReady.perform(data.operations)
+            if (data.cableReady) perform(data.operations)
           }
         }
       )


### PR DESCRIPTION
Fix this error:

```sh
ERROR in ./.yarn/cache/cable_ready-npm-5.0.0-pre3-b6a471a50a-bf6c2acdbd.zip/node_modules/cable_ready/javascript/stream_from_element.js 15:33-51
export 'default' (imported as 'CableReady') was not found in 'cable_ready' (possible exports: initialize, perform, performAsync)
```