### PR TITLE
Server debounce updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     cable_ready (5.0.0.pre3)
+      debouncer (>= 0.2.2)
       rails (>= 5.2)
       thread-local (>= 1.1.0)
 
@@ -94,6 +95,7 @@ GEM
     console (1.13.1)
       fiber-local
     crass (1.0.6)
+    debouncer (0.2.2)
     erubi (1.10.0)
     faraday (1.7.0)
       faraday-em_http (~> 1.0)

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -45,7 +45,7 @@ module CableReady
 
       def cable_ready_update_collection(resource, name)
         identifier = resource.to_global_id.to_s + ":" + name.to_s
-        debouncer.group(identifier).call identifier
+        cable_ready_debouncer.group(identifier).call identifier
       end
 
       def enrich_association_with_updates(name, option)

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -45,7 +45,7 @@ module CableReady
 
       def cable_ready_update_collection(resource, name)
         identifier = resource.to_global_id.to_s + ":" + name.to_s
-        ActionCable.server.broadcast(identifier, {})
+        debouncer.group(identifier).call identifier
       end
 
       def enrich_association_with_updates(name, option)

--- a/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
+++ b/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
@@ -1,10 +1,6 @@
 module CableReady
   module Updatable
     class ModelUpdatableCallbacks
-      extend Debouncer::Debounceable
-
-      debounce :attempt_broadcast, 0.02, grouped: true
-
       def initialize(operation, enabled_operations = %i[create update destroy])
         @operation = operation
         @enabled_operations = enabled_operations
@@ -14,10 +10,6 @@ module CableReady
         return unless @enabled_operations.include?(@operation)
 
         send("broadcast_#{@operation}", model)
-      end
-
-      def attempt_broadcast(identifier)
-        ActionCable.server.broadcast(identifier, {})
       end
 
       private
@@ -30,6 +22,10 @@ module CableReady
       def broadcast_update(model)
         attempt_broadcast model.class
         attempt_broadcast model.to_global_id
+      end
+
+      def attempt_broadcast(identifier)
+        @debouncer.group(identifier).call identifier
       end
     end
   end

--- a/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
+++ b/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
@@ -4,6 +4,7 @@ module CableReady
       def initialize(operation, enabled_operations = %i[create update destroy])
         @operation = operation
         @enabled_operations = enabled_operations
+        @debouncer = Debouncer.new(0.02) { |identifier| ActionCable.server.broadcast(identifier, {}) }
       end
 
       def after_commit(model)

--- a/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
+++ b/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
@@ -1,6 +1,10 @@
 module CableReady
   module Updatable
     class ModelUpdatableCallbacks
+      extend Debouncer::Debounceable
+
+      debounce :attempt_broadcast, 0.02, grouped: true
+
       def initialize(operation, enabled_operations = %i[create update destroy])
         @operation = operation
         @enabled_operations = enabled_operations
@@ -12,16 +16,20 @@ module CableReady
         send("broadcast_#{@operation}", model)
       end
 
+      def attempt_broadcast(identifier)
+        ActionCable.server.broadcast(identifier, {})
+      end
+
       private
 
       def broadcast_create(model)
-        ActionCable.server.broadcast(model.class, {})
+        attempt_broadcast model.class
       end
       alias_method :broadcast_destroy, :broadcast_create
 
       def broadcast_update(model)
-        ActionCable.server.broadcast(model.class, {})
-        ActionCable.server.broadcast(model.to_global_id, {})
+        attempt_broadcast model.class
+        attempt_broadcast model.to_global_id
       end
     end
   end

--- a/app/models/concerns/extend_has_many.rb
+++ b/app/models/concerns/extend_has_many.rb
@@ -9,5 +9,9 @@ module ExtendHasMany
       options[:extend] = Array(options[:extend]).push(ClassMethods)
       super(*args, **options, &block)
     end
+
+    def debouncer
+      @debouncer ||= Debouncer.new(0.02) { |identifier| ActionCable.server.broadcast(identifier, {}) }
+    end
   end
 end

--- a/app/models/concerns/extend_has_many.rb
+++ b/app/models/concerns/extend_has_many.rb
@@ -10,7 +10,7 @@ module ExtendHasMany
       super(*args, **options, &block)
     end
 
-    def debouncer
+    def cable_ready_debouncer
       @debouncer ||= Debouncer.new(0.02) { |identifier| ActionCable.server.broadcast(identifier, {}) }
     end
   end

--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rails", ">= 5.2"
   gem.add_dependency "thread-local", ">= 1.1.0"
+  gem.add_dependency "debouncer", ">=0.2.2"
 
   gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "magic_frozen_string_literal"

--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/engine"
+require "debouncer/debounceable"
 require "open-uri"
 require "active_record"
 require "action_view"

--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "rails/engine"
-require "debouncer/debounceable"
+require "debouncer"
 require "open-uri"
 require "active_record"
 require "action_view"


### PR DESCRIPTION
This is respectfully proposed as a **server-side** alternative to https://github.com/stimulusreflex/cable_ready/pull/151.

It occurred to me that the real problem we're trying to solve is not receiving updates too quickly, but *sending* updates too quickly.

To address the disease and not the symptom, I used the `debouncer` gem to wrap the ActionCable call. It works similarly to the much more familiar JS debouncers that we're familiar with, but because it's Ruby, creates threads.

What I don't know is whether I got my isolation right. I made use of the [grouping mechanism](https://github.com/hx/debouncer) of the `debouncer` gem to treat each identifier as a group. This was reasonably straight-forward for the model callbacks, but in the case of the collection callbacks, I created a class method called `cable_ready_debouncer` which memoizes an instance of `Debouncer`.

I think I got it right, but a sanity check would be really appreciated!