### PR TITLE
Export elements

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -2,6 +2,8 @@ import { xpathToElement, dispatch } from './utils'
 import activeElement from './active_element'
 import OperationStore from './operation_store'
 import actionCable from './action_cable'
+import StreamFromElement from './stream_from_element'
+import UpdatesForElement from './updates_for_element'
 
 const perform = (
   operations,
@@ -73,6 +75,12 @@ const performAsync = (
 const initialize = (initializeOptions = {}) => {
   const { consumer } = initializeOptions
   actionCable.setConsumer(consumer)
+
+  if (!customElements.get('stream-from'))
+    customElements.define('stream-from', StreamFromElement)
+
+  if (!customElements.get('updates-for'))
+    customElements.define('updates-for', UpdatesForElement)
 }
 
 export { perform, performAsync, initialize }

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -3,10 +3,10 @@ import { shouldMorphCallbacks, didMorphCallbacks } from './morph_callbacks'
 import * as Utils from './utils'
 import OperationStore, { addOperation, addOperations } from './operation_store'
 import { perform, performAsync, initialize } from './cable_ready'
-import './stream_from_element'
-import './updates_for_element'
+import StreamFromElement from './stream_from_element'
+import UpdatesForElement from './updates_for_element'
 
-export { Utils, MorphCallbacks }
+export { Utils, MorphCallbacks, StreamFromElement, UpdatesForElement }
 
 export default {
   perform,

--- a/javascript/stream_from_element.js
+++ b/javascript/stream_from_element.js
@@ -1,7 +1,7 @@
 import CableReady from '.'
 import actionCable from './action_cable'
 
-class StreamFromElement extends HTMLElement {
+export default class StreamFromElement extends HTMLElement {
   async connectedCallback () {
     if (this.preview) return
     const consumer = await actionCable.getConsumer()

--- a/javascript/stream_from_element.js
+++ b/javascript/stream_from_element.js
@@ -35,6 +35,3 @@ export default class StreamFromElement extends HTMLElement {
     )
   }
 }
-
-if (!customElements.get('stream-from'))
-  customElements.define('stream-from', StreamFromElement)

--- a/javascript/updates_for_element.js
+++ b/javascript/updates_for_element.js
@@ -111,6 +111,3 @@ export default class UpdatesForElement extends HTMLElement {
       : 20
   }
 }
-
-if (!customElements.get('updates-for'))
-  customElements.define('updates-for', UpdatesForElement)

--- a/javascript/updates_for_element.js
+++ b/javascript/updates_for_element.js
@@ -17,7 +17,7 @@ function url (ele) {
   return ele.hasAttribute('url') ? ele.getAttribute('url') : location.href
 }
 
-class UpdatesForElement extends HTMLElement {
+export default class UpdatesForElement extends HTMLElement {
   constructor () {
     super()
     const shadowRoot = this.attachShadow({ mode: 'open' })


### PR DESCRIPTION
This PR moves defining the elements to `CableReady.initialize`. Since this has to be called anyway, I figured this might be the best place to do it.

Also, it exports `StreamFromElement` and `UpdatesForElement` for outside use.