### PR TITLE
Draft: Futurism updates-for support

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -84,16 +84,26 @@ export default class UpdatesForElement extends SubscribingElement {
         html: fragments[i],
         permanentAttributeName: 'data-ignore-updates'
       }
-      dispatch(blocks[i], 'cable-ready:before-update', operation)
-      morphdom(blocks[i], fragments[i], {
-        childrenOnly: true,
-        onBeforeElUpdated: shouldMorph(operation),
-        onElUpdated: _ => {
-          blocks[i].removeAttribute('updating')
-          dispatch(blocks[i], 'cable-ready:after-update', operation)
-          assignFocus(operation.focusSelector)
-        }
-      })
+
+      if (!blocks[i].dataset.ignoreMorph) {
+        dispatch(blocks[i], 'cable-ready:before-update', operation)
+        morphdom(blocks[i], fragments[i], {
+          childrenOnly: true,
+          onBeforeElUpdated: shouldMorph(operation),
+          onElUpdated: _ => {
+            blocks[i].removeAttribute('updating')
+            dispatch(blocks[i], 'cable-ready:after-update', operation)
+            assignFocus(operation.focusSelector)
+          }
+        })
+      }
+
+      if (blocks[i].dataset.afterUpdateEventSelector) {
+        const elements = blocks[i].querySelectorAll(blocks[i].dataset.afterUpdateEventSelector);
+        elements.forEach(element => {
+          dispatch(element, 'cable-ready:after-update', operation);
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This PR accompanies the following Futurism PR: https://github.com/stimulusreflex/futurism/pull/120

Since I found no other way to instruct morphdom to not mutate the futurism-element I introduced a data attribute to instruct the updates-for element to not call morphdom in the first place.

Secondly I introduced a data attribute that is used to emit a event to the provided selector. This allows futurism to listen to the event and call it's futurism actioncable channel and refresh it's partial without glitching 