### PR TITLE
Add `skip_updates` option

### DIFF
--- a/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
+++ b/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
@@ -15,13 +15,13 @@ module CableReady
       private
 
       def broadcast_create(model)
-        ActionCable.server.broadcast(model.class, {})
+        model.class.send(:broadcast_updates, model.class, {})
       end
       alias_method :broadcast_destroy, :broadcast_create
 
       def broadcast_update(model)
-        ActionCable.server.broadcast(model.class, {})
-        ActionCable.server.broadcast(model.to_global_id, model.respond_to?(:previous_changes) ? {changed: model.previous_changes.keys} : {})
+        model.class.send(:broadcast_updates, model.class, {})
+        model.class.send(:broadcast_updates, model.to_global_id, model.respond_to?(:previous_changes) ? {changed: model.previous_changes.keys} : {})
       end
     end
   end


### PR DESCRIPTION
This adds a `skip_updates` option to wrap any database CRUD changes in that should not be broadcast, for example because they are [happening in an environment without a running Redis server](https://github.com/stimulusreflex/cable_ready/issues/167).

```ruby
# app/models/application_record.rb
class ApplicationRecord < ActiveRecord::Base
  include CableReady::Updatable

  self.abstract_class = true
end

# db/seeds.rb

# Skips broadcasts for all models inheriting from ApplicationRecord:
ApplicationRecord.skip_updates do
  User.destroy_all
  User.create!(user_attrs)
end

# Skips broadcasts for User only:
User.skip_updates do
  # will not broadcast
  User.destroy_all
  User.create!(user_attrs)

  # will broadcast
  Post.destroy_all
  Post.create!(post_attrs)
end
```


Big thanks to @leastbad and @julianrubisch for pointing me in the right direction 🤗 I decided to borrow heavily from ActiveRecord's [no_touching](https://github.com/rails/rails/blob/83217025a171593547d1268651b446d3533e2019/activerecord/lib/active_record/no_touching.rb#L23). Limiting `skip_updates` to the current thread (rather than working with a class variable) means that we don't skip broadcasts for other models or, crucially, other clients. I think that this is the safest option, and can't really think of a use case for one client prohibiting broadcasts for all other clients.