### PR TITLE
fix: resolve error for webpack 5

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,4 +1,4 @@
-import { version } from '../package.json'
+import packageInfo from '../package.json'
 import * as MorphCallbacks from './morph_callbacks'
 import { shouldMorphCallbacks, didMorphCallbacks } from './morph_callbacks'
 import * as Utils from './utils'
@@ -25,7 +25,7 @@ export default {
   consumer,
   addOperation,
   addOperations,
-  version,
+  version: packageInfo.version,
   get DOMOperations () {
     console.warn(
       'DEPRECATED: Please use `CableReady.operations` instead of `CableReady.DOMOperations`'


### PR DESCRIPTION
the error is:
Should not import the named export 'version' (imported as 'version') from
default-exporting module (only default export is available soon)