### PR TITLE
Ignore inner updates on a stimulus-reflex action or turbo submit

### DIFF
--- a/app/helpers/cable_ready_helper.rb
+++ b/app/helpers/cable_ready_helper.rb
@@ -8,11 +8,12 @@ module CableReadyHelper
     tag.stream_from(**build_options(*keys, html_options))
   end
 
-  def updates_for(*keys, url: nil, debounce: nil, only: nil, html_options: {}, &block)
+  def updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, html_options: {}, &block)
     options = build_options(*keys, html_options)
     options[:url] = url if url
     options[:debounce] = debounce if debounce
     options[:only] = only if only
+    options[:"ignore-inner-updates"] = "" if ignore_inner_updates
     tag.updates_for(**options) { capture(&block) }
   end
 

--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -4,6 +4,7 @@ import OperationStore from './operation_store'
 import actionCable from './action_cable'
 import StreamFromElement from './elements/stream_from_element'
 import UpdatesForElement from './elements/updates_for_element'
+import { registerInnerUpdates } from './updatable/inner_updates_compat'
 
 const perform = (
   operations,
@@ -80,6 +81,8 @@ const performAsync = (
 const initialize = (initializeOptions = {}) => {
   const { consumer } = initializeOptions
   actionCable.setConsumer(consumer)
+
+  registerInnerUpdates()
 
   if (!customElements.get('stream-from'))
     customElements.define('stream-from', StreamFromElement)

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -41,18 +41,9 @@ export default class UpdatesForElement extends SubscribingElement {
   }
 
   shouldUpdate (data) {
-    const only = this.getAttribute('only')
-
     return (
-      !(
-        this.hasAttribute('ignore-inner-updates') &&
-        this.hasAttribute('performing-inner-update')
-      ) &&
-      !(
-        only &&
-        data.changed &&
-        !only.split(' ').some(attribute => data.changed.includes(attribute))
-      ) &&
+      !this.ignoringInnerUpdates &&
+      this.hasChangesSelectedForUpdate(data) &&
       this.blocks[0] === this
     )
   }
@@ -145,6 +136,16 @@ export default class UpdatesForElement extends SubscribingElement {
     )
   }
 
+  hasChangesSelectedForUpdate (data) {
+    const only = this.getAttribute('only')
+
+    return !(
+      only &&
+      data.changed &&
+      !only.split(' ').some(attribute => data.changed.includes(attribute))
+    )
+  }
+
   get query () {
     return `updates-for[identifier="${this.identifier}"]`
   }
@@ -157,5 +158,12 @@ export default class UpdatesForElement extends SubscribingElement {
     return this.hasAttribute('debounce')
       ? parseInt(this.getAttribute('debounce'))
       : 20
+  }
+
+  get ignoringInnerUpdates () {
+    return (
+      this.hasAttribute('ignore-inner-updates') &&
+      this.hasAttribute('performing-inner-update')
+    )
   }
 }

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -40,30 +40,33 @@ export default class UpdatesForElement extends SubscribingElement {
     }
   }
 
+  shouldUpdate (data) {
+    const only = this.getAttribute('only')
+
+    return (
+      !(
+        this.hasAttribute('ignore-inner-updates') &&
+        this.hasAttribute('performing-inner-update')
+      ) &&
+      !(
+        only &&
+        data.changed &&
+        !only.split(' ').some(attribute => data.changed.includes(attribute))
+      ) &&
+      this.blocks[0] === this
+    )
+  }
+
   update (data) {
     activeElement.set(document.activeElement)
 
-    if (
-      this.hasAttribute('ignore-inner-updates') &&
-      this.hasAttribute('performing-inner-update')
-    ) {
+    if (!this.shouldUpdate(data)) {
       return
     }
 
-    const blocks = document.querySelectorAll(this.query)
-    if (blocks[0] !== this) return
-
-    const only = this.getAttribute('only')
-    if (
-      only &&
-      data.changed &&
-      !only.split(' ').some(attribute => data.changed.includes(attribute))
-    )
-      return
-
     this.html = {}
 
-    blocks.forEach(this.processBlock.bind(this))
+    this.blocks.forEach(this.processBlock.bind(this))
   }
 
   async processBlock (block, index) {
@@ -144,6 +147,10 @@ export default class UpdatesForElement extends SubscribingElement {
 
   get query () {
     return `updates-for[identifier="${this.identifier}"]`
+  }
+
+  get blocks () {
+    return document.querySelectorAll(this.query)
   }
 
   get debounce () {

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -42,6 +42,14 @@ export default class UpdatesForElement extends SubscribingElement {
 
   update (data) {
     activeElement.set(document.activeElement)
+
+    if (
+      this.hasAttribute('ignore-inner-updates') &&
+      this.hasAttribute('performing-inner-update')
+    ) {
+      return
+    }
+
     const blocks = document.querySelectorAll(this.query)
     if (blocks[0] !== this) return
 

--- a/javascript/updatable/inner_updates_compat.js
+++ b/javascript/updatable/inner_updates_compat.js
@@ -1,0 +1,37 @@
+export const registerInnerUpdates = () => {
+  document.addEventListener('stimulus-reflex:before', event => {
+    recursiveMarkUpdatesForElements(event.detail.element)
+  })
+
+  document.addEventListener('stimulus-reflex:after', event => {
+    setTimeout(() => {
+      recursiveUnmarkUpdatesForElements(event.detail.element)
+    })
+  })
+
+  document.addEventListener('turbo:submit-start', event => {
+    recursiveMarkUpdatesForElements(event.target)
+  })
+
+  document.addEventListener('turbo:submit-end', event => {
+    setTimeout(() => {
+      recursiveUnmarkUpdatesForElements(event.target)
+    })
+  })
+}
+
+const recursiveMarkUpdatesForElements = leaf => {
+  const closestUpdatesFor = leaf.parentElement.closest('updates-for')
+  if (closestUpdatesFor) {
+    closestUpdatesFor.setAttribute('performing-inner-update', '')
+    recursiveMarkUpdatesForElements(closestUpdatesFor)
+  }
+}
+
+const recursiveUnmarkUpdatesForElements = leaf => {
+  const closestUpdatesFor = leaf.parentElement.closest('updates-for')
+  if (closestUpdatesFor) {
+    closestUpdatesFor.removeAttribute('performing-inner-update')
+    recursiveUnmarkUpdatesForElements(closestUpdatesFor)
+  }
+}


### PR DESCRIPTION
Let me preface this PR with the fact that this is already being used successfully in production and is intended as a backmerge of the work I'm doing at https://github.com/code-and-co/.

The idea is to opt out of an `updates_for` operation for the current user on a per-element basis, when a reflex or turbo submit is happening (for example, when wrapping a `<turbo-frame>`).

Conceptually, it consists of 3 parts:

### javascript/updatable/inner_updates_compat.js
which recursively marks every enclosing `updates-for` element with `performing-inner-update`, starting from a reflex or turbo submit initiating element. This attribute is removed again after completion.

### An `ignore_inner_update` option added to the helper
which adds a `ignore-inner-update` attribute to the element on demand.

### A shouldUpdate mechanism 
combining the existing "only" option and returning early when both `ignore-inner-updates` and `performing-inner-update` are set on an element.

cc @andrewerlanger @assuntaw