### PR TITLE
Updated gemspec to specific Rails gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,11 @@ PATH
   remote: .
   specs:
     cable_ready (5.0.0.pre8)
-      rails (>= 5.2)
+      actioncable (>= 5.2)
+      actionpack (>= 5.2)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
       thread-local (>= 1.1.0)
 
 GEM
@@ -126,11 +130,11 @@ GEM
       octokit (~> 4.6)
       rainbow (>= 2.2.1)
       rake (>= 10.0)
-    globalid (0.5.2)
+    globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    loofah (2.12.0)
+    loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     magic_frozen_string_literal (1.2.0)
@@ -221,7 +225,7 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.4.0)
+    sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
@@ -252,9 +256,10 @@ DEPENDENCIES
   mocha
   pry
   pry-nav
+  rails (>= 5.2)
   rake
   sqlite3
   standardrb
 
 BUNDLED WITH
-   2.2.27
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     cable_ready (5.0.0.pre8)
       actioncable (>= 5.2)
       actionpack (>= 5.2)
+      actionview (>= 5.2)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)

--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path("../lib/cable_ready/version", __FILE__)
+require File.expand_path("lib/cable_ready/version", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name = "cable_ready"
@@ -14,15 +14,22 @@ Gem::Specification.new do |gem|
   gem.files = Dir["lib/**/*.rb", "app/**/*.rb", "bin/*", "[A-Z]*"]
   gem.test_files = Dir["test/**/*.rb"]
 
-  gem.add_dependency "rails", ">= 5.2"
+  rails_version = ">= 5.2"
+  gem.add_dependency "actioncable", rails_version
+  gem.add_dependency "actionpack", rails_version
+  gem.add_dependency "activerecord", rails_version
+  gem.add_dependency "activesupport", rails_version
+  gem.add_dependency "railties", rails_version
+
   gem.add_dependency "thread-local", ">= 1.1.0"
 
   gem.add_development_dependency "github_changelog_generator"
   gem.add_development_dependency "magic_frozen_string_literal"
+  gem.add_development_dependency "mocha"
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
+  gem.add_development_dependency "rails", rails_version
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "standardrb"
-  gem.add_development_dependency "mocha"
   gem.add_development_dependency "sqlite3"
+  gem.add_development_dependency "standardrb"
 end

--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   rails_version = ">= 5.2"
   gem.add_dependency "actioncable", rails_version
   gem.add_dependency "actionpack", rails_version
+  gem.add_dependency "actionview", rails_version
   gem.add_dependency "activerecord", rails_version
   gem.add_dependency "activesupport", rails_version
   gem.add_dependency "railties", rails_version


### PR DESCRIPTION
Most apps don't require the full suite of Rails gems, and can avoid installing them to save CI and deploy time. This gem, however, had a dependency on the Rails meta-gem which ended up installing them all anyways.

Instead, we can limit it to only the Rails gems that we directly depend upon.

I'm not sure how to really test this, since the dummy app uses all of Rails. I grep'd through `./lib` to see what parts of Rails were being used, but that might not be comprehensive.

_Note_: I ran `./bin/standardize` as instructed by the README, but it touched dozens of files which I didn't commit as part of this PR.