### PR TITLE
Fix `text_content` operation for nullish values

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -159,7 +159,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, focusSelector } = operation
-        element.textContent = (text != null) ? text || ''
+        element.textContent = (text != null) ? text : ''
         assignFocus(focusSelector)
       })
       after(element, operation)

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -159,7 +159,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, focusSelector } = operation
-        element.textContent = text || ''
+        element.textContent = (text != null) ? text || ''
         assignFocus(focusSelector)
       })
       after(element, operation)


### PR DESCRIPTION
## Type of PR
Bug Fix

### Description

This PR adds a check to make sure that we use the provided `text` parameter if it's not nullish

### Why should this be added

The `text_content` operation always used an empty string for the `text` parameter if the value of the `text` parameter was nullish.

Previously if you passed in `0` as a value for `text` it would have still used the empty string instead.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

