### PR TITLE
Setup automated dev-builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,48 @@
+name: dev-builds
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      - name: Build JavaScript package
+        run: |
+          yarn install
+          yarn build
+          # yarn test
+          yarn pack --filename cable_ready-dev-build.tgz
+      - name: Publish Dev Build 
+        run: |
+          name="$(git log -n 1 --format=format:%cn)"
+          email="$(git log -n 1 --format=format:%ce)"
+          message="$(git log -n 1 --format=format:%s)"
+          date="$(git log -n 1 --format=format:%ai)"
+          
+          tar -xf cable_ready-dev-build.tgz
+          
+          git clone https://github.com/cableready/dev-builds && cd dev-builds
+          git remote remove origin
+          git remote add origin https://${{ secrets.CABLEREADY_BOT_DEV_BUILDS_TOKEN }}@github.com/cableready/dev-builds.git
+
+          git checkout --orphan "${GITHUB_SHA:0:7}"
+          cp -r ../package/. ./
+          git add .
+
+          # git add dist/ javascript/ README.md CHANGELOG.md LICENSE.txt package.json
+          
+          git config --global user.name "$name"
+          git config --global user.email "$email"
+          
+          GIT_COMMITER_DATE=${date} git commit -m "cable_ready/${GITHUB_SHA:0:7} ${message}" --date "${date}"
+          
+          git tag cable_ready/${GITHUB_SHA:0:7} -m "cable_ready/${GITHUB_SHA:0:7} ${message}"
+          git push origin cable_ready/${GITHUB_SHA:0:7}
+        
+        if: ${{ github.event_name == 'push' }}  

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,5 +1,10 @@
 name: dev-builds
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+      
+  pull_request:
 
 jobs:
   build:
@@ -44,5 +49,3 @@ jobs:
           
           git tag cable_ready/${GITHUB_SHA:0:7} -m "cable_ready/${GITHUB_SHA:0:7} ${message}"
           git push origin cable_ready/${GITHUB_SHA:0:7}
-        
-        if: ${{ github.event_name == 'push' }}  


### PR DESCRIPTION
# Type of PR

CI

## Description

This sets up automated dev-builds for all commits and pull requests in order to make the development easier with pre-released code. With #165 we added a build-step to our npm package which might break if you are installing the npm package from a GitHub branch.

Using the first eight characters of the commit hash you can install and use the desired CableReady dev-build in your application.

You can install a dev-build using the `yarn add` command like:

```bash
yarn add cable_ready@https://github.com/cableready/dev-builds/archive/cable_ready/fa083b0.tar.gz
```

or directly replace the `cable_ready` dependency in your `package.json`:
```json5
// package.json
{
  // ...
  "cable_ready": "https://github.com/cableready/dev-builds/archive/cable_ready/fa083b0.tar.gz"
}
```

## Why should this be added

Makes it super easy and straight-forward to use a specific CableReady commit/version in your application.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update