### PR TITLE
CableReady installer

### DIFF
--- a/lib/install/cable_ready_entrypoint.rb
+++ b/lib/install/cable_ready_entrypoint.rb
@@ -1,0 +1,36 @@
+if (js_entrypoint_path = Rails.root.join("app/javascript/application.js")).exist?
+  entrypoint_content = File.read(js_entrypoint_path)
+
+  say "Import CableReady"
+  append_to_file js_entrypoint_path, %(import CableReady from "cable_ready"\n)
+
+  say "Initializing CableReady with ActionCable consumer"
+
+  # Check if there's a channels file, i.e. we're in a webpacker or esbuild setup
+  if Rails.root.join("app/javascript/channels/index.js").exist?
+    unless entrypoint_content.match?(/import consumer/)
+      append_to_file js_entrypoint_path, %(import consumer from "./channels/consumer"\n)
+    end
+
+    append_to_file js_entrypoint_path, %(CableReady.initialize({ consumer })\n)
+
+  # else we could use the cable.consumer from turbo-rails, if present
+  elsif entrypoint_content.match?(/import.*@hotwired\/turbo-rails/)
+    unless entrypoint_content.match?(/import.*cable.*@hotwired\/turbo-rails/)
+      append_to_file js_entrypoint_path, %(import { cable } from "@hotwired\/turbo-rails"\n)
+    end
+
+    append_to_file js_entrypoint_path, <<~JS
+      (async () => {
+        const consumer = await cable.getConsumer()
+        CableReady.initialize({ consumer });
+      })()
+    JS
+
+  # else remind the user to initialize CableReady
+  else
+    say "Please initialize CableReady in #{js_entrypoint_path} with an ActionCable consumer.", :red
+  end
+else
+  say "You must import and initialize cable_ready in your JavaScript entrypoint file", :red
+end

--- a/lib/install/cable_ready_with_importmap.rb
+++ b/lib/install/cable_ready_with_importmap.rb
@@ -1,0 +1,2 @@
+say "Pin CableReady"
+run "bin/importmap pin cable_ready"

--- a/lib/install/cable_ready_with_node.rb
+++ b/lib/install/cable_ready_with_node.rb
@@ -1,0 +1,2 @@
+say "Install CableReady"
+run "yarn add cable_ready"

--- a/lib/install/check_cable_and_redis.rb
+++ b/lib/install/check_cable_and_redis.rb
@@ -1,0 +1,17 @@
+say "Checking ActionCable and Redis"
+
+say "ActionCable configuration (config/cable.yml) is missing. CableReady depends on ActionCable, please provide a config file.", :red unless Rails.root.join("config/cable.yml").exist?
+
+gemfile_content = File.read(Rails.root.join("Gemfile"))
+redis_pattern = /gem ['"]redis['"]/
+
+if gemfile_content.match?(redis_pattern)
+  if gemfile_content.match?(/\s*#\s*#{redis_pattern}/) && yes?("Redis seems to be commented out in your Gemfile. Do you want CableReady to uncomment it?")
+    uncomment_lines "Gemfile", redis_pattern
+  end
+elsif yes?("Redis doesn't seem to be installed in your Rails app. Would you like CableReady to install it?")
+  append_file "Gemfile", "\n# Use Redis for Action Cable"
+  gem "redis", "~> 4.0"
+end
+
+run_bundle

--- a/lib/tasks/cable_ready_tasks.rake
+++ b/lib/tasks/cable_ready_tasks.rake
@@ -1,3 +1,11 @@
+def run_install_template(template)
+  system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/#{template}.rb", __dir__)}"
+end
+
+def check_cable_and_redis
+  run_install_template("check_cable_and_redis")
+end
+
 namespace :cable_ready do
   desc "Install CableReady into the app"
   task :install do
@@ -13,12 +21,14 @@ namespace :cable_ready do
   namespace :install do
     desc "Install CableReady into the app with asset pipeline"
     task :importmap do
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/cable_ready_with_importmap.rb", __dir__)}"
+      check_cable_and_redis
+      run_install_template("cable_ready_with_importmap")
     end
 
     desc "Install CableReady into the app with node"
     task :node do
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/cable_ready_with_node.rb", __dir__)}"
+      check_cable_and_redis
+      run_install_template("cable_ready_with_node")
     end
   end
 end

--- a/lib/tasks/cable_ready_tasks.rake
+++ b/lib/tasks/cable_ready_tasks.rake
@@ -1,0 +1,24 @@
+namespace :cable_ready do
+  desc "Install CableReady into the app"
+  task :install do
+    if Rails.root.join("config/importmap.rb").exist?
+      Rake::Task["cable_ready:install:importmap"].invoke
+    elsif Rails.root.join("package.json").exist?
+      Rake::Task["cable_ready:install:node"].invoke
+    else
+      puts "You must either be running with node (package.json) or importmap-rails (config/importmap.rb) to use this gem."
+    end
+  end
+
+  namespace :install do
+    desc "Install CableReady into the app with asset pipeline"
+    task :importmap do
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/cable_ready_with_importmap.rb", __dir__)}"
+    end
+
+    desc "Install CableReady into the app with node"
+    task :node do
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../install/cable_ready_with_node.rb", __dir__)}"
+    end
+  end
+end

--- a/lib/tasks/cable_ready_tasks.rake
+++ b/lib/tasks/cable_ready_tasks.rake
@@ -23,12 +23,14 @@ namespace :cable_ready do
     task :importmap do
       check_cable_and_redis
       run_install_template("cable_ready_with_importmap")
+      run_install_template("cable_ready_entrypoint")
     end
 
     desc "Install CableReady into the app with node"
     task :node do
       check_cable_and_redis
       run_install_template("cable_ready_with_node")
+      run_install_template("cable_ready_entrypoint")
     end
   end
 end


### PR DESCRIPTION
I've taken a first stab at the _new unified CableReady Installer_, and borrowed heavily from https://github.com/hotwired/turbo-rails/blob/main/lib/tasks/turbo_tasks.rake

Let me break it down for you a bit:

- basically we have 2 install tasks, `cable_ready:install:importmap`, and `cable_ready:install:node`, where the main `cable_ready:install` task switches on the presence of an `importmap.rb` file
- both installers do a sanity check if Redis and ActionCable are available, and optionally asks the user if Redis should be installed (https://github.com/stimulusreflex/cable_ready/pull/179/files#diff-e469da9bc01523658da7d880f0c454118061110611e92e21c3d69e0232ae983aR8)
- the installers then do their `pin`/`yarn add` actions
- finally, initializing CableReady in the application's entrypoint. I've taken my own experience as a heuristic here:
  1. `import CableReady from "cable_ready"
  2. if a `./channels/index.js` is present, we're likely in a webpacker setup. Use that consumer to initialize CR.
  3. if no such channels index is present, we can fall back on using the `cable` module exposed by `@hotwired/turbo-rails`.
  4. else ask the user to do it manually.

I've tested many scenarios locally, but doing a bit of testing certainly wouldn't hurt 🙏 