### PR TITLE
updates-for should respect url and only params on each element

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -46,9 +46,6 @@ export default class UpdatesForElement extends SubscribingElement {
   }
 
   update (data) {
-    // memoize blocks to avoid unnecessary DOM traversal
-    this.blocks = document.querySelectorAll(this.query)
-
     // first updates-for element in the DOM *at any given moment* updates all of the others
     if (this.blocks[0] !== this) return
 
@@ -158,7 +155,7 @@ export default class UpdatesForElement extends SubscribingElement {
   shouldUpdate (data, block) {
     // if everything that could prevent an update is false, update this block
     return (
-      this.processInnerUpdates(block) &&
+      !this.ignoresInnerUpdates(block) &&
       this.hasChangesSelectedForUpdate(data, block)
     )
   }
@@ -174,12 +171,19 @@ export default class UpdatesForElement extends SubscribingElement {
     )
   }
 
-  processInnerUpdates (block) {
+  ignoresInnerUpdates (block) {
     // don't update during a Reflex or Turbolinks redraw
-    return !(
+    return (
       block.hasAttribute('ignore-inner-updates') &&
       block.hasAttribute('performing-inner-update')
     )
+  }
+
+  get blocks () {
+    // memoize blocks to avoid unnecessary DOM traversal
+    if (!this._blocks) this._blocks = document.querySelectorAll(this.query)
+
+    return this._blocks
   }
 
   get query () {


### PR DESCRIPTION
Reworked updates-for element to allow per-block url and only attributes. URL fragment indexes are now tracked on a per-URL basis.

That means the following contrived example works as you'd expect:

`index.html.erb`
```erb
<%= updates_for current_user, :posts do %>
  <% Post.all.each do |p| %>
    <p><%= p.name %>, <%= p.email %></p>
  <% end %>
  <p><%= rand(1..1000) %></p>
<% end %>

<%= updates_for current_user, :posts, only: [:name] do %>
  <% Post.all.each do |p| %>
    <p><%= p.name %>, <%= p.email %></p>
  <% end %>
  <p><%= rand(1..1000) %></p>
<% end %>

<%= updates_for current_user, :posts, url: "/updates_for" do %>
  <% Post.all.each do |p| %>
    <p><%= p.name %>, <%= p.email %></p>
  <% end %>
  <p><%= rand(1..1000) %></p>
<% end %>

<%= updates_for current_user, :posts, only: [:name], url: "/updates_for" do %>
  <% Post.all.each do |p| %>
    <p><%= p.name %>, <%= p.email %></p>
  <% end %>
  <p><%= rand(1..1000) %></p>
<% end %>
```
`updates_for.html.erb`
```erb
<%= updates_for current_user, :posts do %>
  <p>HAIRY!</p>
  <p><%= rand(1..1000) %></p>
<% end %>
```
No, I don't know why `Post` has a `name` and `email`. Don't ask hard questions.
```ruby
post = current_user.posts.create name: "Fred", email: "fred@gmail.com"
post.update name: "Frederick" # updates the first three blocks, plus console warning
post.update email: "frederick@gmail.com" # updates only the first and third
```
Note that the 4th block will not be updated because `updates_for.html.erb` only has one block; a warning is generated in the console to suggest that there wasn't enough elements for the update to complete.

Unfortunately this will certainly clash with #181 as written, although I have done my best to maintain the general structure and naming to ease merge conflicts.