### PR TITLE
Export utils

### DIFF
--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -149,5 +149,7 @@ export {
   after,
   debounce,
   handleErrors,
-  graciouslyFetch
+  graciouslyFetch,
+  debounce,
+  kebabize
 }


### PR DESCRIPTION
Export `kebabize` so it can be reused in child libraries (SR, futurism, cubism etc.) thus saving on bundle size.