### PR TITLE
multi-element XPath support

### DIFF
--- a/javascript/cable_ready.js
+++ b/javascript/cable_ready.js
@@ -1,4 +1,4 @@
-import { xpathToElement, dispatch } from './utils'
+import { xpathToElement, xpathToElementArray, dispatch } from './utils'
 
 import ActiveElement from './active_element'
 import OperationStore from './operation_store'
@@ -18,11 +18,15 @@ const perform = (
     const name = operation.operation
     try {
       if (operation.selector) {
-        operation.element = operation.xpath
-          ? xpathToElement(operation.selector)
-          : document[
-              operation.selectAll ? 'querySelectorAll' : 'querySelector'
-            ](operation.selector)
+        if (operation.xpath) {
+          operation.element = operation.selectAll
+            ? xpathToElementArray(operation.selector)
+            : xpathToElement(operation.selector)
+        } else {
+          operation.element = operation.selectAll
+            ? document.querySelectorAll(operation.selector)
+            : document.querySelector(operation.selector)
+        }
       } else {
         operation.element = document
       }

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -45,6 +45,22 @@ const xpathToElement = xpath => {
   ).singleNodeValue
 }
 
+// Accepts an xPath query and returns all matching elements in the DOM
+//
+const xpathToElementArray = xpath => {
+  const result = document.evaluate(
+    xpath,
+    document,
+    null,
+    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+    null
+  )
+  const elements = []
+  for (let i = 0; i < result.snapshotLength; i++)
+    elements.push(result.snapshotItem(i))
+  return elements
+}
+
 // Return an array with the class names to be used
 //
 // * names - could be a string or an array of strings for multiple classes.

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -158,6 +158,7 @@ export {
   assignFocus,
   dispatch,
   xpathToElement,
+  xpathToElementArray,
   getClassNames,
   processElements,
   operate,


### PR DESCRIPTION
Acting on a request from @W3NDO, this PR would allow the `select_all` option to co-exist with `xpath` selectors.

It required the introduction of a `xpathToElementArray` utility function, which returns an Array of nodes (that could be empty, depending on your query results).