### PR TITLE
Add option to disable Turbo Drive/Turbolinks on `redirectTo` navigation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -329,11 +329,17 @@ export default {
   redirectTo: operation => {
     before(window, operation)
     operate(operation, () => {
-      let { url, action } = operation
+      let { url, action, turbo } = operation
       action = action || 'advance'
-      if (window.Turbo) window.Turbo.visit(url, { action })
-      if (window.Turbolinks) window.Turbolinks.visit(url, { action })
-      if (!window.Turbo && !window.Turbolinks) window.location.href = url
+      if (typeof turbo === 'undefined') turbo = true
+      
+      if (turbo) {
+        if (window.Turbo) window.Turbo.visit(url, { action })
+        if (window.Turbolinks) window.Turbolinks.visit(url, { action })
+        if (!window.Turbo && !window.Turbolinks) window.location.href = url
+      } else {
+        window.location.href = url
+      }
     })
     after(window, operation)
   },


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

@mepatterson asked on Discord if it's possible to use the `redirectTo` operation without using Turbo and Turbolinks even though it's actually installed and setup in the app. There are some edge-cases were you might want to not use the `visit()` function.

## Why should this be added

This Pull Requests adds an option to disable the navigation with Turbo/Turbolinks in the `redirectTo` operation, since there is no simple way to disable the use of the `Turbo[links].visit()`.

You could also solve this issue with a simple custom operation like:
```js
CableReady.operations.navigate = (operation) => {
  window.location.href = operation.url
}
```

But it somehow seems redundant since there's already an operation which pretty handles this out of the box, if configured properly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update