### PR TITLE
Add an `invoke_method` operation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -179,16 +179,23 @@ export default {
     })
   },
 
-  callMethod: operation => {
+  invokeMethod: operation => {
     processElements(operation, element => {
       before(element, operation)
       operate(operation, () => {
-        const { name, args } = operation
-        if (!element[name]) {
-          console.warn(`CableReady callMethod failed due to missing '${name}' method for element:`, element)
-          return
+        const { element, receiver, method, args } = operation
+        const chain = method.split('.')
+        const obj = receiver === 'window' ? window : element
+        const foundMethod = chain.reduce((lastTerm, nextTerm) => (lastTerm[nextTerm] || {}), obj)
+
+        if (foundMethod instanceof Function) {
+          foundMethod(...(args || []))
+        } else {
+          console.warn(
+            `CableReady invokeMethod failed due to missing '${method}' method for:`,
+            receiver === 'window' ? window : element
+          )
         }
-        element[name](...(args || []))
       })
       after(element, operation)
     })

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -207,7 +207,7 @@ export default {
           foundMethod.apply(lastObjectInChain, args || [])
         } else {
           console.warn(
-            `CableReady invoke_method failed due to missing '${method}' method for:`, firstObjectInChain
+            `CableReady invoke_method operation failed due to missing '${method}' method for:`, firstObjectInChain
           )
         }
       })

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -188,7 +188,7 @@ export default {
           console.warn(`CableReady callMethod failed due to missing '${name}' method for element:`, element)
           return
         }
-        element[name](...args)
+        element[name](...(args || []))
       })
       after(element, operation)
     })

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -179,6 +179,21 @@ export default {
     })
   },
 
+  callMethod: operation => {
+    processElements(operation, element => {
+      before(element, operation)
+      operate(operation, () => {
+        const { name, args } = operation
+        if (!element[name]) {
+          console.warn(`CableReady callMethod failed due to missing '${name}' method for element:`, element)
+          return
+        }
+        element[name](...args)
+      })
+      after(element, operation)
+    })
+  },
+
   removeAttribute: operation => {
     processElements(operation, element => {
       before(element, operation)

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -40,7 +40,6 @@ module CableReady
       Set.new(%i[
         add_css_class
         append
-        call_method
         clear_storage
         console_log
         console_table
@@ -50,6 +49,7 @@ module CableReady
         inner_html
         insert_adjacent_html
         insert_adjacent_text
+        invoke_method
         morph
         notification
         outer_html

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -40,6 +40,7 @@ module CableReady
       Set.new(%i[
         add_css_class
         append
+        call_method
         clear_storage
         console_log
         console_table


### PR DESCRIPTION
This adds an operation which allows you to call a JavaScript method for an element, whether that's a builtin HTML element or a custom element. Or you can use `window` as the receiver instead of an element. Example:

```ruby
cable_car.invoke_method "#some-element", method: :doSomething,
                                         args: ["wow", { very: "cool" }], # you can (optionally) pass any number of args via an array
                                         delay: 1000 # as with all operations now, you can delay it by X ms

cable_car.invoke_method receiver: :window, method: "Turbo.visit", args: ["/path"]
```

- [ ] Documentation
- [ ] Tests (not sure how?)