### PR TITLE
Add `.rake` to gemspec `files` glob pattern

### DIFF
--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary = "Out-of-Band Server Triggered DOM Operations"
 
   gem.files = Dir[
-    "lib/**/*.rb",
+    "lib/**/*.{rb,rake}",
     "app/**/*.rb",
     "app/assets/javascripts/*",
     "bin/*",


### PR DESCRIPTION
# Type of PR

Improvement

## Description / Why should this be added

CableReady is going to get it's own installers soon (see #179). In order for the rake files to be inculded we need to add the `.rake` extension to the gemspec. This PR is analog to https://github.com/stimulusreflex/stimulus_reflex/pull/581. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update
