### PR TITLE
Add conditional updates_for helper

### DIFF
--- a/app/helpers/cable_ready_helper.rb
+++ b/app/helpers/cable_ready_helper.rb
@@ -17,6 +17,14 @@ module CableReadyHelper
     tag.updates_for(**options) { capture(&block) }
   end
 
+  def updates_for_if(condition, *keys, **options, &block)
+    if condition
+      updates_for(*keys, **options, &block)
+    else
+      capture(&block)
+    end
+  end
+
   private
 
   def build_options(*keys, html_options)

--- a/test/lib/cable_ready/helper_test.rb
+++ b/test/lib/cable_ready/helper_test.rb
@@ -22,4 +22,20 @@ class CableReady::HelperTest < ActionView::TestCase
     assert_equal "block", element.children.first["class"]
     assert_equal "modal", element.children.first["data-controller"]
   end
+
+  # conditional updates_for
+
+  test "updates_for_if renders if condition is met" do
+    element = Nokogiri::HTML.fragment(updates_for_if(true, "key") { tag.div })
+
+    assert_equal "updates-for", element.children.first.name
+    refute_equal "div", element.children.first.name
+  end
+
+  test "updates_for_if doesn't render if condition isn't met" do
+    element = Nokogiri::HTML.fragment(updates_for_if(false, "key") { tag.div })
+
+    refute_equal "updates-for", element.children.first.name
+    assert_equal "div", element.children.first.name
+  end
 end


### PR DESCRIPTION
In the app I'm currently developing, it has occurred that I want to conditionally wrap a block of ERB in `updates_for` based on authorization. So typically one would do:

```erb
<% if policy(post).edit? %>
  <%= updates_for post ... %>
    <%= post.content %>
  <% end %>
<% else %>
  <%= post.content %>
<% end %>
```

which, depending on your setup, might lead to a lot of duplication. This PR simplifies it to

```erb
<%= updates_for_if policy(post).edit?, post ... %>
  <%= post.content %>
<% end %>
```

in the spirit of `link_to_if` etc.