### PR TITLE
Explicit check for leaf parent element presence for updates_for

### DIFF
--- a/javascript/updatable/inner_updates_compat.js
+++ b/javascript/updatable/inner_updates_compat.js
@@ -21,7 +21,8 @@ export const registerInnerUpdates = () => {
 }
 
 const recursiveMarkUpdatesForElements = leaf => {
-  const closestUpdatesFor = leaf && leaf.parentElement.closest('updates-for')
+  const closestUpdatesFor =
+    leaf && leaf.parentElement && leaf.parentElement.closest('updates-for')
   if (closestUpdatesFor) {
     closestUpdatesFor.setAttribute('performing-inner-update', '')
     recursiveMarkUpdatesForElements(closestUpdatesFor)
@@ -29,7 +30,8 @@ const recursiveMarkUpdatesForElements = leaf => {
 }
 
 const recursiveUnmarkUpdatesForElements = leaf => {
-  const closestUpdatesFor = leaf && leaf.parentElement.closest('updates-for')
+  const closestUpdatesFor =
+    leaf && leaf.parentElement && leaf.parentElement.closest('updates-for')
   if (closestUpdatesFor) {
     closestUpdatesFor.removeAttribute('performing-inner-update')
     recursiveUnmarkUpdatesForElements(closestUpdatesFor)


### PR DESCRIPTION
In certain scenarios, the call to recursive updates associated with updates_for may fail if the leaf's parent Element is null.  

This results in an error similar to the following:
`Uncaught TypeError: e2.parentElement is null`

To prevent the error we'll perform an explicit check on the presence of the parent element before attempting to call closest().

