### PR TITLE
fixed 0 value problem with null checks

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -7,7 +7,10 @@ import {
   processElements,
   before,
   after,
-  operate
+  operate,
+  safeString,
+  safeArray,
+  safeObject
 } from './utils'
 
 export default {
@@ -18,7 +21,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('beforeend', html != null ? html : '')
+        element.insertAdjacentHTML('beforeend', safeString(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -45,7 +48,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.innerHTML = html != null ? html : ''
+        element.innerHTML = safeString(html)
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -57,10 +60,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, position, focusSelector } = operation
-        element.insertAdjacentHTML(
-          position || 'beforeend',
-          html != null ? html : ''
-        )
+        element.insertAdjacentHTML(position || 'beforeend', safeString(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -72,10 +72,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, position, focusSelector } = operation
-        element.insertAdjacentText(
-          position || 'beforeend',
-          text != null ? text : ''
-        )
+        element.insertAdjacentText(position || 'beforeend', safeString(text))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -115,7 +112,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = html != null ? html : ''
+        element.outerHTML = safeString(html)
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -127,7 +124,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('afterbegin', html != null ? html : '')
+        element.insertAdjacentHTML('afterbegin', safeString(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -153,7 +150,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = html != null ? html : ''
+        element.outerHTML = safeString(html)
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -165,7 +162,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, focusSelector } = operation
-        element.textContent = text != null ? text : ''
+        element.textContent = safeString(text)
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -179,7 +176,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.add(...getClassNames(name != null ? name : ''))
+        element.classList.add(...getClassNames(safeString(name)))
       })
       after(element, operation)
     })
@@ -212,7 +209,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.setAttribute(name, value != null ? value : '')
+        element.setAttribute(name, safeString(value))
       })
       after(element, operation)
     })
@@ -223,7 +220,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.dataset[name] = value != null ? value : ''
+        element.dataset[name] = safeString(value)
       })
       after(element, operation)
     })
@@ -234,7 +231,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        if (name in element) element[name] = value != null ? value : ''
+        if (name in element) element[name] = safeString(value)
       })
       after(element, operation)
     })
@@ -245,7 +242,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.style[name] = value != null ? value : ''
+        element.style[name] = safeString(value)
       })
       after(element, operation)
     })
@@ -257,7 +254,7 @@ export default {
       operate(operation, () => {
         const { styles } = operation
         for (let [name, value] of Object.entries(styles))
-          element.style[name] = value != null ? value : ''
+          element.style[name] = safeString(value)
       })
       after(element, operation)
     })
@@ -268,7 +265,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { value } = operation
-        element.value = value != null ? value : ''
+        element.value = safeString(value)
       })
       after(element, operation)
     })
@@ -364,11 +361,7 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.pushState(
-        state != null ? state : {},
-        title != null ? title : '',
-        url
-      )
+      history.pushState(safeObject(state), safeString(title), url)
     })
     after(window, operation)
   },
@@ -413,11 +406,7 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.replaceState(
-        state != null ? state : {},
-        title != null ? title : '',
-        url
-      )
+      history.replaceState(safeObject(state), safeString(title), url)
     })
     after(window, operation)
   },
@@ -435,7 +424,7 @@ export default {
     before(document, operation)
     operate(operation, () => {
       const { cookie } = operation
-      document.cookie = cookie != null ? cookie : ''
+      document.cookie = safeString(cookie)
     })
     after(document, operation)
   },
@@ -454,7 +443,7 @@ export default {
     operate(operation, () => {
       const { key, value, type } = operation
       const storage = type === 'session' ? sessionStorage : localStorage
-      storage.setItem(key, value != null ? value : '')
+      storage.setItem(key, safeString(value))
     })
     after(document, operation)
   },
@@ -466,8 +455,8 @@ export default {
     operate(operation, () => {
       const { message, level } = operation
       level && ['warn', 'info', 'error'].includes(level)
-        ? console[level](message != null ? message : '')
-        : console.log(message != null ? message : '')
+        ? console[level](safeString(message))
+        : console.log(safeString(message))
     })
     after(document, operation)
   },
@@ -476,7 +465,7 @@ export default {
     before(document, operation)
     operate(operation, () => {
       const { data, columns } = operation
-      console.table(data, columns != null ? columns : [])
+      console.table(data, safeArray(columns))
     })
     after(document, operation)
   },
@@ -487,8 +476,7 @@ export default {
       const { title, options } = operation
       Notification.requestPermission().then(result => {
         operation.permission = result
-        if (result === 'granted')
-          new Notification(title != null ? title : '', options)
+        if (result === 'granted') new Notification(safeString(title), options)
       })
     })
     after(document, operation)

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -364,7 +364,11 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.pushState(state || {}, title != null ? title : '', url)
+      history.pushState(
+        state != null ? state : {},
+        title != null ? title : '',
+        url
+      )
     })
     after(window, operation)
   },

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -18,7 +18,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('beforeend', html || '')
+        element.insertAdjacentHTML('beforeend', html != null ? html : '')
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -45,7 +45,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.innerHTML = html || ''
+        element.innerHTML = html != null ? html : ''
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -57,7 +57,10 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, position, focusSelector } = operation
-        element.insertAdjacentHTML(position || 'beforeend', html || '')
+        element.insertAdjacentHTML(
+          position || 'beforeend',
+          html != null ? html : ''
+        )
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -69,7 +72,10 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, position, focusSelector } = operation
-        element.insertAdjacentText(position || 'beforeend', text || '')
+        element.insertAdjacentText(
+          position || 'beforeend',
+          text != null ? text : ''
+        )
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -109,7 +115,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = html || ''
+        element.outerHTML = html != null ? html : ''
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -121,7 +127,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('afterbegin', html || '')
+        element.insertAdjacentHTML('afterbegin', html != null ? html : '')
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -147,7 +153,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = html || ''
+        element.outerHTML = html != null ? html : ''
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -173,7 +179,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.add(...getClassNames(name || ''))
+        element.classList.add(...getClassNames(name != null ? name : ''))
       })
       after(element, operation)
     })
@@ -206,7 +212,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.setAttribute(name, value || '')
+        element.setAttribute(name, value != null ? value : '')
       })
       after(element, operation)
     })
@@ -217,7 +223,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.dataset[name] = value || ''
+        element.dataset[name] = value != null ? value : ''
       })
       after(element, operation)
     })
@@ -228,7 +234,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        if (name in element) element[name] = value || ''
+        if (name in element) element[name] = value != null ? value : ''
       })
       after(element, operation)
     })
@@ -239,7 +245,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.style[name] = value || ''
+        element.style[name] = value != null ? value : ''
       })
       after(element, operation)
     })
@@ -251,7 +257,7 @@ export default {
       operate(operation, () => {
         const { styles } = operation
         for (let [name, value] of Object.entries(styles))
-          element.style[name] = value || ''
+          element.style[name] = value != null ? value : ''
       })
       after(element, operation)
     })
@@ -262,7 +268,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { value } = operation
-        element.value = value || ''
+        element.value = value != null ? value : ''
       })
       after(element, operation)
     })
@@ -358,7 +364,7 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.pushState(state || {}, title || '', url)
+      history.pushState(state || {}, title != null ? title : '', url)
     })
     after(window, operation)
   },
@@ -403,7 +409,11 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.replaceState(state || {}, title || '', url)
+      history.replaceState(
+        state != null ? state : {},
+        title != null ? title : '',
+        url
+      )
     })
     after(window, operation)
   },
@@ -421,7 +431,7 @@ export default {
     before(document, operation)
     operate(operation, () => {
       const { cookie } = operation
-      document.cookie = cookie || ''
+      document.cookie = cookie != null ? cookie : ''
     })
     after(document, operation)
   },
@@ -440,7 +450,7 @@ export default {
     operate(operation, () => {
       const { key, value, type } = operation
       const storage = type === 'session' ? sessionStorage : localStorage
-      storage.setItem(key, value || '')
+      storage.setItem(key, value != null ? value : '')
     })
     after(document, operation)
   },
@@ -452,8 +462,8 @@ export default {
     operate(operation, () => {
       const { message, level } = operation
       level && ['warn', 'info', 'error'].includes(level)
-        ? console[level](message || '')
-        : console.log(message || '')
+        ? console[level](message != null ? message : '')
+        : console.log(message != null ? message : '')
     })
     after(document, operation)
   },
@@ -462,7 +472,7 @@ export default {
     before(document, operation)
     operate(operation, () => {
       const { data, columns } = operation
-      console.table(data, columns || [])
+      console.table(data, columns != null ? columns : [])
     })
     after(document, operation)
   },
@@ -473,7 +483,8 @@ export default {
       const { title, options } = operation
       Notification.requestPermission().then(result => {
         operation.permission = result
-        if (result === 'granted') new Notification(title || '', options)
+        if (result === 'granted')
+          new Notification(title != null ? title : '', options)
       })
     })
     after(document, operation)

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -455,8 +455,8 @@ export default {
     operate(operation, () => {
       const { message, level } = operation
       level && ['warn', 'info', 'error'].includes(level)
-        ? console[level](safeString(message))
-        : console.log(safeString(message))
+        ? console[level](message)
+        : console.log(message)
     })
     after(document, operation)
   },
@@ -476,7 +476,8 @@ export default {
       const { title, options } = operation
       Notification.requestPermission().then(result => {
         operation.permission = result
-        if (result === 'granted') new Notification(safeString(title), options)
+        if (result === 'granted')
+          new Notification(safeString(title), safeObject(options))
       })
     })
     after(document, operation)

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -176,7 +176,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.add(...getClassNames(safeString(name)))
+        element.classList.add(...getClassNames([safeString(name)]))
       })
       after(element, operation)
     })
@@ -198,7 +198,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.remove(...getClassNames(name))
+        element.classList.remove(...getClassNames([name]))
       })
       after(element, operation)
     })

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -8,6 +8,7 @@ import {
   before,
   after,
   operate,
+  safeScalar,
   safeString,
   safeArray,
   safeObject
@@ -21,7 +22,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('beforeend', safeString(html))
+        element.insertAdjacentHTML('beforeend', safeScalar(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -48,7 +49,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.innerHTML = safeString(html)
+        element.innerHTML = safeScalar(html)
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -60,7 +61,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, position, focusSelector } = operation
-        element.insertAdjacentHTML(position || 'beforeend', safeString(html))
+        element.insertAdjacentHTML(position || 'beforeend', safeScalar(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -72,7 +73,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, position, focusSelector } = operation
-        element.insertAdjacentText(position || 'beforeend', safeString(text))
+        element.insertAdjacentText(position || 'beforeend', safeScalar(text))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -83,7 +84,7 @@ export default {
     processElements(operation, element => {
       const { html } = operation
       const template = document.createElement('template')
-      template.innerHTML = String(html).trim()
+      template.innerHTML = String(safeScalar(html)).trim()
       operation.content = template.content
       const parent = element.parentElement
       const ordinal = Array.from(parent.children).indexOf(element)
@@ -112,7 +113,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = safeString(html)
+        element.outerHTML = safeScalar(html)
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -124,7 +125,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.insertAdjacentHTML('afterbegin', safeString(html))
+        element.insertAdjacentHTML('afterbegin', safeScalar(html))
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -150,7 +151,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
-        element.outerHTML = safeString(html)
+        element.outerHTML = safeScalar(html)
         assignFocus(focusSelector)
       })
       after(parent.children[ordinal], operation)
@@ -162,7 +163,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { text, focusSelector } = operation
-        element.textContent = safeString(text)
+        element.textContent = safeScalar(text)
         assignFocus(focusSelector)
       })
       after(element, operation)
@@ -187,7 +188,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.removeAttribute(name)
+        element.removeAttribute(safeString(name))
       })
       after(element, operation)
     })
@@ -198,7 +199,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.remove(...getClassNames([name]))
+        element.classList.remove(...getClassNames([safeString(name)]))
       })
       after(element, operation)
     })
@@ -209,7 +210,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.setAttribute(name, safeString(value))
+        element.setAttribute(safeString(name), safeScalar(value))
       })
       after(element, operation)
     })
@@ -220,7 +221,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.dataset[name] = safeString(value)
+        element.dataset[safeString(name)] = safeScalar(value)
       })
       after(element, operation)
     })
@@ -231,7 +232,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        if (name in element) element[name] = safeString(value)
+        if (name in element) element[safeString(name)] = safeScalar(value)
       })
       after(element, operation)
     })
@@ -242,7 +243,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, value } = operation
-        element.style[name] = safeString(value)
+        element.style[safeString(name)] = safeScalar(value)
       })
       after(element, operation)
     })
@@ -254,7 +255,7 @@ export default {
       operate(operation, () => {
         const { styles } = operation
         for (let [name, value] of Object.entries(styles))
-          element.style[name] = safeString(value)
+          element.style[safeString(name)] = safeScalar(value)
       })
       after(element, operation)
     })
@@ -265,7 +266,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { value } = operation
-        element.value = safeString(value)
+        element.value = safeScalar(value)
       })
       after(element, operation)
     })
@@ -278,7 +279,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name, detail } = operation
-        dispatch(element, name, detail)
+        dispatch(element, safeString(name), safeObject(detail))
       })
       after(element, operation)
     })
@@ -290,7 +291,7 @@ export default {
       operate(operation, () => {
         let firstObjectInChain
         const { element, receiver, method, args } = operation
-        const chain = method.split('.')
+        const chain = safeString(method).split('.')
 
         switch (receiver) {
           case 'window':
@@ -328,10 +329,10 @@ export default {
       let meta = document.head.querySelector(`meta[name='${name}']`)
       if (!meta) {
         meta = document.createElement('meta')
-        meta.name = name
+        meta.name = safeString(name)
         document.head.appendChild(meta)
       }
-      meta.content = content
+      meta.content = safeScalar(content)
     })
     after(document, operation)
   },
@@ -397,7 +398,7 @@ export default {
     operate(operation, () => {
       const { key, type } = operation
       const storage = type === 'session' ? sessionStorage : localStorage
-      storage.removeItem(key)
+      storage.removeItem(safeString(key))
     })
     after(document, operation)
   },
@@ -424,7 +425,7 @@ export default {
     before(document, operation)
     operate(operation, () => {
       const { cookie } = operation
-      document.cookie = safeString(cookie)
+      document.cookie = safeScalar(cookie)
     })
     after(document, operation)
   },
@@ -443,7 +444,7 @@ export default {
     operate(operation, () => {
       const { key, value, type } = operation
       const storage = type === 'session' ? sessionStorage : localStorage
-      storage.setItem(key, safeString(value))
+      storage.setItem(safeString(key), safeScalar(value))
     })
     after(document, operation)
   },

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -362,7 +362,7 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.pushState(safeObject(state), safeString(title), url)
+      history.pushState(safeObject(state), safeString(title), safeString(url))
     })
     after(window, operation)
   },
@@ -372,7 +372,8 @@ export default {
     operate(operation, () => {
       let { url, action, turbo } = operation
       action = action || 'advance'
-      if (typeof turbo === 'undefined') turbo = true
+      url = safeString(url)
+      if (turbo === undefined) turbo = true
 
       if (turbo) {
         if (window.Turbo) window.Turbo.visit(url, { action })
@@ -407,7 +408,11 @@ export default {
     before(window, operation)
     operate(operation, () => {
       const { state, title, url } = operation
-      history.replaceState(safeObject(state), safeString(title), url)
+      history.replaceState(
+        safeObject(state),
+        safeString(title),
+        safeString(url)
+      )
     })
     after(window, operation)
   },

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -130,27 +130,32 @@ function handleErrors (response) {
   return response
 }
 
+function safeScalar (val) {
+  if (
+    val !== undefined &&
+    !['string', 'number', 'boolean'].includes(typeof val)
+  )
+    console.warn(
+      `Operation expects a string, number or boolean, but got ${val} (${typeof val})`
+    )
+  return val != null ? val : ''
+}
+
 function safeString (str) {
-  if (typeof str !== 'string') {
-    console.warn(`Operation requires a String, but got ${str} (${typeof str})`)
-    return ''
-  }
+  if (str !== undefined && typeof str !== 'string')
+    console.warn(`Operation expects a string, but got ${str} (${typeof str})`)
   return str != null ? String(str) : ''
 }
 
 function safeArray (arr) {
-  if (!Array.isArray(arr)) {
-    console.warn(`Operation requires an Array, but got ${arr} (${typeof arr})`)
-    return []
-  }
+  if (arr !== undefined && !Array.isArray(arr))
+    console.warn(`Operation expects an array, but got ${arr} (${typeof arr})`)
   return arr != null ? Array.from(arr) : []
 }
 
 function safeObject (obj) {
-  if (typeof obj !== 'object') {
-    console.warn(`Operation requires an Object, but got ${obj} (${typeof obj})`)
-    return {}
-  }
+  if (obj !== undefined && typeof obj !== 'object')
+    console.warn(`Operation expects an object, but got ${obj} (${typeof obj})`)
   return obj != null ? Object(obj) : {}
 }
 
@@ -192,6 +197,7 @@ export {
   handleErrors,
   graciouslyFetch,
   kebabize,
+  safeScalar,
   safeString,
   safeArray,
   safeObject

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -65,7 +65,7 @@ const xpathToElementArray = xpath => {
 //
 // * names - could be a string or an array of strings for multiple classes.
 //
-const getClassNames = names => Array(names).flat()
+const getClassNames = names => Array.from(names).flat()
 
 // Perform operation for either the first or all of the elements returned by CSS selector
 //

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -131,14 +131,26 @@ function handleErrors (response) {
 }
 
 function safeString (str) {
+  if (typeof str !== 'string') {
+    console.warn(`Operation requires a String, but got ${str} (${typeof str})`)
+    return ''
+  }
   return str != null ? String(str) : ''
 }
 
 function safeArray (arr) {
+  if (!Array.isArray(arr)) {
+    console.warn(`Operation requires an Array, but got ${arr} (${typeof arr})`)
+    return []
+  }
   return arr != null ? Array.from(arr) : []
 }
 
 function safeObject (obj) {
+  if (typeof obj !== 'object') {
+    console.warn(`Operation requires an Object, but got ${obj} (${typeof obj})`)
+    return {}
+  }
   return obj != null ? Object(obj) : {}
 }
 

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -130,6 +130,18 @@ function handleErrors (response) {
   return response
 }
 
+function safeString (str) {
+  return str != null ? str : ''
+}
+
+function safeArray (arr) {
+  return arr != null ? arr : []
+}
+
+function safeObject (obj) {
+  return obj != null ? obj : {}
+}
+
 // A proxy method to wrap a fetch call in error handling
 //
 // * url - the URL to fetch
@@ -167,5 +179,8 @@ export {
   debounce,
   handleErrors,
   graciouslyFetch,
-  kebabize
+  kebabize,
+  safeString,
+  safeArray,
+  safeObject
 }

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -131,15 +131,15 @@ function handleErrors (response) {
 }
 
 function safeString (str) {
-  return str != null ? str : ''
+  return str != null ? String(str) : ''
 }
 
 function safeArray (arr) {
-  return arr != null ? arr : []
+  return arr != null ? Array.from(arr) : []
 }
 
 function safeObject (obj) {
-  return obj != null ? obj : {}
+  return obj != null ? Object(obj) : {}
 }
 
 // A proxy method to wrap a fetch call in error handling


### PR DESCRIPTION
I applied @marcoroth's `value != null ? value : ''` to the CR operations which previously would have read `value || ''`. The issue was that if the developer sends `0` as a value, in JS `0` is falsey and so the OR falls over to `''`.

Some applications are more straightforward than others. Anything where a text/html value was being written, this is an obvious fix. However, in an attempt to be thorough, I also updated a few that I would appreciate 👀 on:

- `addCssClass`: can you have a class with the name `0`? I sort of doubt it.
- `pushState` and `replaceState`: should I be applying this to the `state` param? (I have it falling back to `{}`)
- `setCookie`: is this appropriate?
- `consoleTable`: is this appropriate?