### PR TITLE
`OperationBuilder#apply!` should be able to handle an array of operations

### DIFF
--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -64,7 +64,7 @@ module CableReady
       rescue JSON::ParserError
         {}
       end
-      @enqueued_operations.push(operations)
+      @enqueued_operations.concat(Array.wrap(operations))
       self
     end
 

--- a/test/lib/cable_ready/operation_builder_test.rb
+++ b/test/lib/cable_ready/operation_builder_test.rb
@@ -81,6 +81,15 @@ class CableReady::OperationBuilderTest < ActiveSupport::TestCase
     assert_equal({"name" => "passed_option"}, operations.first)
   end
 
+  test "should apply! many operations from an array" do
+    @operation_builder.apply!([{name: "passed_option_1"}, {name: "passed_option_2"}])
+
+    operations = @operation_builder.instance_variable_get(:@enqueued_operations)
+    assert_equal 2, operations.size
+    assert_equal({"name" => "passed_option_1"}, operations.first)
+    assert_equal({"name" => "passed_option_2"}, operations.last)
+  end
+
   test "operations payload should omit empty operations" do
     @operation_builder.add_operation_method("foobar")
     payload = @operation_builder.operations_payload


### PR DESCRIPTION
# Type of PR 

Bug Fix

## Description

The `OperationBuilder#apply!` method somehow didn't account for passing an Array into it when trying to apply operations to a channel. Instead it added the array of operations to the `@enqueued_operations` ending up in a nested array.

## Why should this be added

The nested `@enqueued_operations` resulted in a `NoMethodError (undefined method 'deep_transform_keys!' for []:Array):` when trying to use in combination with the `.broadcast_later` method. This PR fixes the `apply!` method to also take an array of operations.


```ruby
irb(main):002:0> cable_ready["example"].broadcast_later
Enqueued CableReadyBroadcastJob (Job ID: f7e8dd9b-8072-406c-8228-1d7cc36307ec) to Async(default) with arguments: {:identifier=>"example", :operations=>[]}
=> nil
Performing CableReadyBroadcastJob (Job ID: f7e8dd9b-8072-406c-8228-1d7cc36307ec) from Async(default) enqueued at 2022-07-17T16:27:01Z with arguments: {:identifier=>"example", :operations=>[]}
irb(main):005:0> Error performing CableReadyBroadcastJob (Job ID: f7e8dd9b-8072-406c-8228-1d7cc36307ec) from Async(default) in 10.67ms: NoMethodError (undefined method `deep_transform_keys!' for []:Array):
```

To reproduce:

```ruby
irb(main):001:0> include CableReady::Broadcaster
=> Object

irb(main):002:0> cable_ready["example"].apply!([{"message"=>"Hello World", "operation"=>"consoleLog"}])
=>
#<CableReady::Channel:0x00007f9160b786f0
 @enqueued_operations=[[{"message"=>"Hello World", "operation"=>"consoleLog"}]],
 @identifier="example",
 @previous_selector=nil>

# notice the nested array in @enqueued_operations

irb(main):003:0> cable_ready["example"].broadcast
/Users/marcoroth/Development/cable_ready/lib/cable_ready/operation_builder.rb:72:in `block in operations_payload': undefined method `deep_transform_keys!' for [{"message"=>"Hello World", "operation"=>"consoleLog"}]:Array (NoMethodError)
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update