### PR TITLE
missing element warnings

### DIFF
--- a/javascript/elements/index.js
+++ b/javascript/elements/index.js
@@ -1,5 +1,5 @@
 import CableConsumer from '../cable_consumer'
-
+import MissingElement from '../missing_element'
 import CableReadyElement from './cable_ready_element'
 import StreamFromElement from './stream_from_element'
 import UpdatesForElement from './updates_for_element'
@@ -7,7 +7,7 @@ import UpdatesForElement from './updates_for_element'
 import { registerInnerUpdates } from '../updatable/inner_updates_compat'
 
 const initialize = (initializeOptions = {}) => {
-  const { consumer } = initializeOptions
+  const { consumer, onMissingElement } = initializeOptions
 
   registerInnerUpdates()
 
@@ -18,6 +18,8 @@ const initialize = (initializeOptions = {}) => {
       'CableReady requires a reference to your Action Cable `consumer` for its helpers to function.\nEnsure that you have imported the `CableReady` package as well as `consumer` from your `channels` folder, then call `CableReady.initialize({ consumer })`.'
     )
   }
+
+  if (onMissingElement) MissingElement.set(onMissingElement)
 
   CableReadyElement.define()
   StreamFromElement.define()

--- a/javascript/missing_element.js
+++ b/javascript/missing_element.js
@@ -1,0 +1,13 @@
+let missingElement = 'warn'
+
+export default {
+  get behavior () {
+    return missingElement
+  },
+  set (value) {
+    if (['warn', 'ignore', 'event', 'exception'].includes(value))
+      missingElement = value
+    else
+      console.warn("Invalid 'onMissingElement' option. Defaulting to 'warn'.")
+  }
+}


### PR DESCRIPTION
Here's a pass at customizable missing element warnings. I'm not attached to my approach; feel free to suggest different variable names, different attribute names, changes to the behaviour of the different modes.

I should also say that it occurred to me only as I was typing this up that perhaps this is actually the wrong approach; instead of specifically addressing missing elements, perhaps it would be better to implement a `debug` concept that would allow the developer to make decisions for all errors. There are lots of warnings etc in the codebase that have nothing to do with missing elements. **Opinions, please!**

After deliberation, I took Marco's idea to have multiple strategies and ran with it. I figure that we can always pull these extra options out if we don't want them.

`CableReady.initialize` now supports an `onMissingElement` option which sets a global value. As always, it defaults to warnings (`warn`) but also supports `ignore`, `event`, `exception`. It will warn if you pass an invalid option, falling back to `warn`.
```js
CableReady.initialize({ consumer, onMissingElement: 'event' })
```
`event` raises a `cable-ready:missing-element` event on `document`. `exception` throws an exception.

The `emitMissingElementWarnings` option on `perform` and `performAsync` has been removed in favor of `onMissingElement`. It's a major version bump, after all. A value provided overrides the global value.

```js
if (data.cableReady) perform(data.operations, { onMissingElement: 'exception' })
```

We could optionally test for `emitMissingElementWarnings: false`, issue a deprecation warning and set `onMissingElement: 'ignore'`, but it's not implemented at this time. **Opinions, please!**

Finally, the `stream_from` web component checks for a `missing` attribute and falls back to the global setting. The WC supports `warn`, `ignore` and `event`, but *not* `exception`. This is because there's no way for a developer to `catch` an exception raised by the WC.
```erb
<%= stream_from :all_users, html_options: {missing: :ignore} %>
```
Again, I'm happy to change the attribute. I started with short and simple, because `missing-element` requires using double-quotes which I find ugly:
```erb
<%= stream_from :all_users, html_options: {"missing-element": :ignore} %>
```