### PR TITLE
documentElement doesn't have a parent

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -87,7 +87,7 @@ export default {
       template.innerHTML = String(safeScalar(html)).trim()
       operation.content = template.content
       const parent = element.parentElement
-      const ordinal = Array.from(parent.children).indexOf(element)
+      const idx = parent && Array.from(parent.children).indexOf(element)
       before(element, operation)
       operate(operation, () => {
         const { childrenOnly, focusSelector } = operation
@@ -102,21 +102,21 @@ export default {
         )
         assignFocus(focusSelector)
       })
-      after(parent.children[ordinal], operation)
+      after(parent ? parent.children[idx] : document.documentElement, operation)
     })
   },
 
   outerHtml: operation => {
     processElements(operation, element => {
       const parent = element.parentElement
-      const ordinal = Array.from(parent.children).indexOf(element)
+      const idx = parent && Array.from(parent.children).indexOf(element)
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
         element.outerHTML = safeScalar(html)
         assignFocus(focusSelector)
       })
-      after(parent.children[ordinal], operation)
+      after(parent ? parent.children[idx] : document.documentElement, operation)
     })
   },
 
@@ -147,14 +147,14 @@ export default {
   replace: operation => {
     processElements(operation, element => {
       const parent = element.parentElement
-      const ordinal = Array.from(parent.children).indexOf(element)
+      const idx = parent && Array.from(parent.children).indexOf(element)
       before(element, operation)
       operate(operation, () => {
         const { html, focusSelector } = operation
         element.outerHTML = safeScalar(html)
         assignFocus(focusSelector)
       })
-      after(parent.children[ordinal], operation)
+      after(parent ? parent.children[idx] : document.documentElement, operation)
     })
   },
 

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -159,6 +159,10 @@ function safeObject (obj) {
   return obj != null ? Object(obj) : {}
 }
 
+function fragmentToString (fragment) {
+  return new XMLSerializer().serializeToString(fragment)
+}
+
 // A proxy method to wrap a fetch call in error handling
 //
 // * url - the URL to fetch
@@ -200,5 +204,6 @@ export {
   safeScalar,
   safeString,
   safeArray,
-  safeObject
+  safeObject,
+  fragmentToString
 }


### PR DESCRIPTION
In the process of testing https://github.com/stimulusreflex/stimulus_reflex/pull/601, I realized that three operations attempt to access the `parentElement`. This doesn't work out if you are targeting `html`.

Snuck in a tiny util function, `fragmentToString`. I intend to use it for tests and etc.