### PR TITLE
CableReady Operation Mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in cable_ready.gemspec
 gemspec
+
+gem 'turbo-rails', github: 'marcoroth/turbo-rails', branch: 'turbo-stream-additional-attributes'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       activesupport (>= 5.2)
       railties (>= 5.2)
       thread-local (>= 1.1.0)
+      turbo-rails
 
 GEM
   remote: https://rubygems.org/
@@ -170,6 +171,10 @@ GEM
       standard
     thor (1.1.0)
     thread-local (1.1.0)
+    turbo-rails (1.1.1)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/marcoroth/turbo-rails.git
+  revision: d38861125d86fb6b4aa70d4db44afd81e609fa03
+  branch: turbo-stream-additional-attributes
+  specs:
+    turbo-rails (1.1.1)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
+
 PATH
   remote: .
   specs:
@@ -171,10 +181,6 @@ GEM
       standard
     thor (1.1.0)
     thread-local (1.1.0)
-    turbo-rails (1.1.1)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -198,6 +204,7 @@ DEPENDENCIES
   rake
   sqlite3
   standardrb
+  turbo-rails!
 
 BUNDLED WITH
    2.2.33

--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activerecord", rails_version
   gem.add_dependency "activesupport", rails_version
   gem.add_dependency "railties", rails_version
+  gem.add_dependency "turbo-rails"
 
   gem.add_dependency "thread-local", ">= 1.1.0"
 

--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -21,6 +21,19 @@ require "cable_ready/channels"
 require "cable_ready/cable_car"
 require "cable_ready/stream_identifier"
 
+require "turbo-rails"
+turbo = Gem::Specification.find_by_name("turbo-rails").gem_dir
+
+module Turbo
+  module Streams
+  end
+end
+
+require "#{turbo}/app/helpers/turbo/streams/action_helper"
+require "#{turbo}/app/models/turbo/streams/tag_builder"
+require "#{turbo}/app/helpers/turbo/streams_helper"
+
+
 module CableReady
   class << self
     def config

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -7,7 +7,7 @@ module CableReady
     include Observable
     include Singleton
 
-    attr_accessor :on_failed_sanity_checks, :on_new_version_available
+    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :operation_mode
     attr_writer :verifier_key
 
     def initialize
@@ -15,6 +15,7 @@ module CableReady
       @operation_names = Set.new(default_operation_names)
       @on_failed_sanity_checks = :exit
       @on_new_version_available = :ignore
+      @operation_mode = :cable_ready
     end
 
     def observers

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -108,9 +108,10 @@ module CableReady
         @enqueued_operations.map do |operation|
           turbo_action = translate_operation_name(operation["operation"])
           turbo_target, target_attribute = translate_selector(operation)
-          turbo_template = operation["html"] || operation[:html] || operation["message"]
+          turbo_template = operation["html"] || operation[:html]
+          attributes = operation.except("operation", "selector", "html", "domId", "dom_id", :dom_id, :html).deep_transform_keys { |key| key.to_s.dasherize }
 
-          turbo_stream_action_tag(turbo_action, target_attribute => turbo_target, template: turbo_template)
+          turbo_stream_action_tag(turbo_action, target_attribute => turbo_target, template: turbo_template, **attributes)
         end
       else
         @enqueued_operations.map { |operation| operation.deep_transform_keys! { |key| key.to_s.camelize(:lower) } }

--- a/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
+++ b/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
@@ -11,6 +11,11 @@ CableReady.configure do |config|
 
   # config.on_new_version_available = :ignore
 
+  # Specify operations payload output format, options:
+  # `:cable_ready` or `:turbo_stream`
+
+  # config.operation_mode = :turbo_stream
+
   # Define your own custom operations
   # https://cableready.stimulusreflex.com/customization#custom-operations
 

--- a/test/lib/cable_ready/operation_builder_turbo_stream_test.rb
+++ b/test/lib/cable_ready/operation_builder_turbo_stream_test.rb
@@ -58,12 +58,8 @@ class CableReady::OperationBuilderTurboStreamTest < ActiveSupport::TestCase
     @operation_builder.add_operation_method("foobar")
     @operation_builder.foobar({name: "passed_option"})
 
-    # the Turbo Helper current don't supoport custom additional attributes
-    # assert_equal("<turbo-stream action=\"foobar\" targets=\"body\" name=\"passed_option\"><template></template></turbo-stream>", @operation_builder.to_turbo_stream)
-    # assert_equal("<turbo-stream action=\"foobar\" targets=\"body\" name=\"passed_option\"><template></template></turbo-stream>", @operation_builder.to_html)
-
-    assert_equal("<turbo-stream action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_turbo_stream)
-    assert_equal("<turbo-stream action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_html)
+    assert_equal("<turbo-stream name=\"passed_option\" action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_turbo_stream)
+    assert_equal("<turbo-stream name=\"passed_option\" action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_html)
   end
 
   test "operations payload should omit empty operations" do
@@ -77,9 +73,7 @@ class CableReady::OperationBuilderTurboStreamTest < ActiveSupport::TestCase
     @operation_builder.add_operation_method("foo_bar")
     @operation_builder.foo_bar({beep_boop: "passed_option"})
 
-    # the Turbo Helper current don't supoport custom additional attributes
-    # operations = ["<turbo-stream action=\"fooBar\" targets=\"body\" beep-boop=\"passed_option\"><template></template></turbo-stream>"]
-    operations = ["<turbo-stream action=\"fooBar\" targets=\"body\"><template></template></turbo-stream>"]
+    operations = ["<turbo-stream beep-boop=\"passed_option\" action=\"fooBar\" targets=\"body\"><template></template></turbo-stream>"]
 
     assert_equal(operations, @operation_builder.operations_payload)
   end
@@ -185,9 +179,7 @@ class CableReady::OperationBuilderTurboStreamTest < ActiveSupport::TestCase
 
     @operation_builder.console_log(message: "Hello Console", level: "warn")
 
-    # the Turbo Helper current don't supoport custom additional attributes
-    # operations = ["<turbo-stream action=\"consoleLog\" targets=\"body\" level="warn"><template>Hello Console</template></turbo-stream>"]
-    operations = ["<turbo-stream action=\"consoleLog\" targets=\"body\"><template>Hello Console</template></turbo-stream>"]
+    operations = ["<turbo-stream message=\"Hello Console\" level=\"warn\" action=\"consoleLog\" targets=\"body\"><template></template></turbo-stream>"]
 
     assert_equal(operations, @operation_builder.operations_payload)
   end

--- a/test/lib/cable_ready/operation_builder_turbo_stream_test.rb
+++ b/test/lib/cable_ready/operation_builder_turbo_stream_test.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require_relative "../../../lib/cable_ready"
+
+class Death
+  def to_html
+    "I rock"
+  end
+
+  def to_dom_id
+    "death"
+  end
+
+  def to_operation_options
+    [:html, :dom_id, :spaz]
+  end
+end
+
+class Life
+  def to_operation_options
+    {
+      html: "You go, girl",
+      dom_id: "life"
+    }
+  end
+end
+
+class CableReady::OperationBuilderTurboStreamTest < ActiveSupport::TestCase
+  setup do
+    CableReady.config.operation_mode = :turbo_stream
+    @operation_builder = CableReady::OperationBuilder.new("test")
+  end
+
+  teardown do
+    CableReady.config.operation_mode = :cable_ready
+  end
+
+  test "should create enqueued operations" do
+    assert_not_nil @operation_builder.instance_variable_get(:@enqueued_operations)
+  end
+
+  test "should add observer to cable ready" do
+    assert_not_nil CableReady.config.instance_variable_get(:@observer_peers)[@operation_builder]
+  end
+
+  test "should remove observer when destroyed" do
+    @operation_builder = nil
+    assert_nil CableReady.config.instance_variable_get(:@observer_peers)[@operation_builder]
+  end
+
+  test "should add operation method" do
+    @operation_builder.add_operation_method("foobar")
+    assert @operation_builder.respond_to?(:foobar)
+  end
+
+  test "should operations convert operations to Turbo Stream / HTML" do
+    @operation_builder.add_operation_method("foobar")
+    @operation_builder.foobar({name: "passed_option"})
+
+    # the Turbo Helper current don't supoport custom additional attributes
+    # assert_equal("<turbo-stream action=\"foobar\" targets=\"body\" name=\"passed_option\"><template></template></turbo-stream>", @operation_builder.to_turbo_stream)
+    # assert_equal("<turbo-stream action=\"foobar\" targets=\"body\" name=\"passed_option\"><template></template></turbo-stream>", @operation_builder.to_html)
+
+    assert_equal("<turbo-stream action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_turbo_stream)
+    assert_equal("<turbo-stream action=\"foobar\" targets=\"body\"><template></template></turbo-stream>", @operation_builder.to_html)
+  end
+
+  test "operations payload should omit empty operations" do
+    @operation_builder.add_operation_method("foobar")
+    assert_equal([], @operation_builder.operations_payload)
+    assert_equal("", @operation_builder.to_html)
+    assert_equal("", @operation_builder.to_turbo_stream)
+  end
+
+  test "operations payload should camelize keys" do
+    @operation_builder.add_operation_method("foo_bar")
+    @operation_builder.foo_bar({beep_boop: "passed_option"})
+
+    # the Turbo Helper current don't supoport custom additional attributes
+    # operations = ["<turbo-stream action=\"fooBar\" targets=\"body\" beep-boop=\"passed_option\"><template></template></turbo-stream>"]
+    operations = ["<turbo-stream action=\"fooBar\" targets=\"body\"><template></template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should take first argument as selector" do
+    @operation_builder.add_operation_method("inner_html")
+
+    @operation_builder.inner_html("#smelly", html: "<span>I rock</span>")
+
+    operations = ["<turbo-stream action=\"replace\" target=\"smelly\"><template><span>I rock</span></template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should use previously passed selector in next operation" do
+    @operation_builder.add_operation_method("inner_html")
+    @operation_builder.add_operation_method("set_focus")
+
+    @operation_builder.set_focus("#smelly").inner_html(html: "<span>I rock</span>")
+
+    operations = [
+      "<turbo-stream action=\"setFocus\" target=\"smelly\"><template></template></turbo-stream>",
+      "<turbo-stream action=\"replace\" target=\"smelly\"><template><span>I rock</span></template></turbo-stream>"
+    ]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should clear previous_selector after calling reset!" do
+    @operation_builder.add_operation_method("inner_html")
+    @operation_builder.inner_html(selector: "#smelly", html: "<span>I rock</span>")
+
+    @operation_builder.reset!
+
+    @operation_builder.inner_html(html: "<span>winning</span>")
+
+    operations = ["<turbo-stream action=\"replace\" targets=\"body\"><template><span>winning</span></template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should use previous_selector if present and should use `selector` if explicitly provided" do
+    @operation_builder.add_operation_method("inner_html")
+    @operation_builder.add_operation_method("set_focus")
+
+    @operation_builder.set_focus("#smelly").inner_html(html: "<span>I rock</span>").inner_html(html: "<span>I rock too</span>", selector: "#smelly2")
+
+    operations = [
+      "<turbo-stream action=\"setFocus\" target=\"smelly\"><template></template></turbo-stream>",
+      "<turbo-stream action=\"replace\" target=\"smelly\"><template><span>I rock</span></template></turbo-stream>",
+      "<turbo-stream action=\"replace\" target=\"smelly2\"><template><span>I rock too</span></template></turbo-stream>",
+    ]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html option from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(html: death)
+
+    operations = ["<turbo-stream action=\"replace\" targets=\"body\"><template>I rock</template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html option with selector from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(death, html: death)
+
+    operations = ["<turbo-stream action=\"replace\" target=\"death\"><template>I rock</template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html and dom_id options from Death object" do
+    @operation_builder.add_operation_method("inner_html")
+    death = Death.new
+
+    @operation_builder.inner_html(death)
+
+    operations = ["<turbo-stream action=\"replace\" target=\"death\"><template>I rock</template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should pull html and dom_id options from Life object" do
+    @operation_builder.add_operation_method("inner_html")
+    life = Life.new
+
+    @operation_builder.inner_html(life)
+
+    operations = ["<turbo-stream action=\"replace\" target=\"life\"><template>You go, girl</template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
+  test "should put operation[message] into the tempalte tag" do
+    @operation_builder.add_operation_method("console_log")
+
+    @operation_builder.console_log(message: "Hello Console", level: "warn")
+
+    # the Turbo Helper current don't supoport custom additional attributes
+    # operations = ["<turbo-stream action=\"consoleLog\" targets=\"body\" level="warn"><template>Hello Console</template></turbo-stream>"]
+    operations = ["<turbo-stream action=\"consoleLog\" targets=\"body\"><template>Hello Console</template></turbo-stream>"]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+end


### PR DESCRIPTION
# Type of PR

Feature

## Description

I had this one sitting around for a while, but thought I'll open this as a draft PR for visibility. 

This PR allows CableReady and/or CableCar to operate in the `cable_ready` or `turbo_stream` operation mode.

```ruby
# config/initializers/cable_ready.rb

CableReady.configure do |config|
  # Specify operations payload output format, options:
  # `:cable_ready` or `:turbo_stream`

  config.operation_mode = :turbo_stream
end
```

When the `turbo_stream` operation mode is set, it will output any enqueued CableReady operations as `<turbo-stream>` tags.

Example:
```ruby
include CableReady::Broadcaster

cable_car.inner_html(selector: "#time", html: "<div>#{Time.now}</div>").dispatch

# => "<turbo-stream action=\"replace\" target=\"time\"><template><div>2022-08-29 23:20:03 +0200</div></template></turbo-stream>"
```

When the operation mode is set is set to `cable_ready` you can still output the `turbo_stream` format by calling `.to_turbo_stream` after the last operation:

```ruby
cable_car.inner_html(selector: "#smelly", html: "<div>#{Time.now}</div>").to_turbo_stream

# => "<turbo-stream action=\"replace\" target=\"time\"><template><div>2022-08-29 23:20:03 +0200</div></template></turbo-stream>"
```
 
This also allows CableCar to be used in contexts where you usually would use the `turbo_stream` helper:
```ruby
# app/controllers/some_controller.rb

def show
  render turbo_stream: cable_car.inner_html(selector: "#time", html: "<div>#{Time.now}</div>").dispatch_event(name: "requested", selector: "body")
end
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

