### PR TITLE
Modernize StandardRB GitHub Action

### DIFF
--- a/.github/workflows/standardrb.yml
+++ b/.github/workflows/standardrb.yml
@@ -2,19 +2,20 @@ name: StandardRB
 
 on:
   pull_request:
-    branches:
-      - '*'
   push:
-    branches:
-      - master
 
 jobs:
   standard:
     name: StandardRB Check Action
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Standard
-      uses: CultureHQ/actions-bundler@master
-      with:
-        args: install && bundle exec standardrb --format progress
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          bundler-cache: true
+
+      - name: Run standardrb
+        run: bundle exec standardrb --format progress


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Updates the StandardRB GitHub Action to run on a more recent Ruby version and removes the now deprecated [`CultureHQ/actions-bundler`](https://github.com/CultureHQ/actions-bundler) action.

## Why should this be added

Removes one "dependency", makes the action faster and should resolve the issues around standardrb in #222.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

