### PR TITLE
Rename Helper to ViewHelper so Rails will include it correctly

### DIFF
--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CableReady
-  module Helper
+  module ViewHelper
     include CableReady::Compoundable
     include CableReady::StreamIdentifier
 

--- a/lib/cable_ready_helper.rb
+++ b/lib/cable_ready_helper.rb
@@ -4,6 +4,6 @@
 
 module CableReadyHelper
   def self.included(base)
-    raise "`CableReadyHelper` was renamed to `CableReady::Helper`"
+    raise "`CableReadyHelper` was renamed to `CableReady::ViewHelper`"
   end
 end

--- a/test/lib/cable_ready/view_helper_test.rb
+++ b/test/lib/cable_ready/view_helper_test.rb
@@ -2,8 +2,8 @@
 
 require "test_helper"
 
-class CableReady::HelperTest < ActionView::TestCase
-  include CableReady::Helper
+class CableReady::ViewHelperTest < ActionView::TestCase
+  include CableReady::ViewHelper
 
   # stream_from
 
@@ -62,6 +62,6 @@ class CableReady::HelperTest < ActionView::TestCase
       RaiseHelperTest.new
     end
 
-    assert_equal "`CableReadyHelper` was renamed to `CableReady::Helper`", expection.message
+    assert_equal "`CableReadyHelper` was renamed to `CableReady::ViewHelper`", expection.message
   end
 end


### PR DESCRIPTION
# Bug fix

## Description

Recently @marcoroth namespaced the helper file under the CableReady namespace (#220). This broke using `stream_from` view helper since Rails seems to prefer a helper be called xxxHelper. I've made a suggestion to rename Helper to ViewHelper. I'm very open to other names though.

## Why should this be added

This makes the `stream_from`, `updates_for` and other view helpers work again.