### PR TITLE
fix `updates_for` makes redundant calls

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -55,10 +55,10 @@ export default class UpdatesForElement extends SubscribingElement {
     const blocks = Array.from(
       document.querySelectorAll(this.query),
       element => new Block(element)
-    )
+    ).filter(block => block.shouldUpdate(data))
 
     // first updates-for element in the DOM *at any given moment* updates all of the others
-    if (blocks[0].element !== this) return
+    if (blocks.length === 0 || blocks[0].element !== this) return
 
     // hold a reference to the active element so that it can be restored after the morph
     ActiveElement.set(document.activeElement)
@@ -113,9 +113,6 @@ class Block {
   }
 
   async process (data, html, index) {
-    // with the index incremented, we can now safely bail - before a fetch - if there's no work to be done
-    if (!this.shouldUpdate(data)) return
-
     const blockIndex = index[this.url]
     const template = document.createElement('template')
     this.element.setAttribute('updating', 'updating')


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Modify `updates_for` element to verify that a page is required before fetching it.

This PR essentially implements the suggestion made in #209, with minor tweaks.

I've done my best to test this new functionality, but I am not a heavy user of `updates_for` and would appreciate if @julianrubisch could sanity check this. Specifically, my concern is that there could be an unexpected interaction with lazily loaded Turbo Frame content?

I was concerned that filtering out blocks might cause the index-based element selection to point to the wrong element, but so far, I haven't been able to trip it up. I really don't want to break this functionality.

@andrewerlanger I also removed the previous line 117, which was where we performed the `shouldUpdate` check initially. It seems as though this should no longer be necessary. Is there a good reason to run the check again?

I've tested on a simple User model with `enable_updates`, as well as `name` and `email` attributes:
```erb
<%= updates_for current_user, only: :email do %>
  <p><%= current_user.name %></p>
  <p><%= current_user.email %></p>
<% end %>

<%= updates_for current_user, only: :name do %>
  <p><%= current_user.name %></p>
  <p><%= current_user.email %></p>
<% end %>
```
Seems to work fine when I update either attribute.

Fixes #209 

## Why should this be added

@andrewerlanger pointed out that we fetch pages from the server before checking if they are used, which is a waste of computing resources and bandwidth.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update