### PR TITLE
Fix bug where using an array when calling (add/remove)_css_class didn…

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -11,7 +11,8 @@ import {
   safeScalar,
   safeString,
   safeArray,
-  safeObject
+  safeObject,
+  safeStringOrArray
 } from './utils'
 
 export default {
@@ -177,7 +178,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.add(...getClassNames([safeString(name)]))
+        element.classList.add(...getClassNames([safeStringOrArray(name)]))
       })
       after(element, operation)
     })
@@ -199,7 +200,7 @@ export default {
       before(element, operation)
       operate(operation, () => {
         const { name } = operation
-        element.classList.remove(...getClassNames([safeString(name)]))
+        element.classList.remove(...getClassNames([safeStringOrArray(name)]))
       })
       after(element, operation)
     })

--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -201,6 +201,7 @@ export default {
       operate(operation, () => {
         const { name } = operation
         element.classList.remove(...getClassNames([safeStringOrArray(name)]))
+        if (element.classList.length === 0) element.removeAttribute('class')
       })
       after(element, operation)
     })

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -151,6 +151,7 @@ function safeScalar (val) {
 function safeString (str) {
   if (str !== undefined && typeof str !== 'string')
     console.warn(`Operation expects a string, but got ${str} (${typeof str})`)
+
   return str != null ? String(str) : ''
 }
 
@@ -164,6 +165,13 @@ function safeObject (obj) {
   if (obj !== undefined && typeof obj !== 'object')
     console.warn(`Operation expects an object, but got ${obj} (${typeof obj})`)
   return obj != null ? Object(obj) : {}
+}
+
+function safeStringOrArray (elem) {
+  if (elem !== undefined && !Array.isArray(elem) && typeof elem !== 'string')
+    console.warn(`Operation expects an Array or a String, but got ${elem} (${typeof elem})`)
+
+  return elem == null ? '' : Array.isArray(elem) ? Array.from(elem) : String(elem)
 }
 
 function fragmentToString (fragment) {
@@ -212,5 +220,6 @@ export {
   safeString,
   safeArray,
   safeObject,
+  safeStringOrArray,
   fragmentToString
 }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
This is a bugfix for #231 , while the original issue only mentions `add_css_class` while working on this, I realized that the same bug affected `remove_css_class` and so fixed that too.

## Description

Please include a summary of the change and which issue is fixed.

Fixes #231 

## Why should this be added
It fixes a bug.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update

Please note that the best way to suggest changes or updates to the [documentation](https://docs.stimulusreflex.com) is to [join Discord](https://discord.gg/stimulus-reflex) and leave a note in the #docs channel. Any documentation updates posted as PRs cannot be accepted at this time. :heart:
