### PR TITLE
set_title operation

### DIFF
--- a/javascript/operations.js
+++ b/javascript/operations.js
@@ -339,6 +339,15 @@ export default {
     after(document, operation)
   },
 
+  setTitle: operation => {
+    before(document, operation)
+    operate(operation, () => {
+      const { title } = operation
+      document.title = safeScalar(title)
+    })
+    after(document, operation)
+  },
+
   // Browser Manipulations
 
   clearStorage: operation => {

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -73,6 +73,7 @@ module CableReady
         set_storage_item
         set_style
         set_styles
+        set_title
         set_value
         text_content
       ]).freeze


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Feature

## Description

`cable_ready.set_title(title: "Introducing...")`

## Why should this be added

@drnic needs a `set_title` operation, so he gets one.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
- [x] This is not a documentation update