### PR TITLE
chore: Make Updatable aware of Turbo Boost Commands

### DIFF
--- a/javascript/updatable/inner_updates_compat.js
+++ b/javascript/updatable/inner_updates_compat.js
@@ -18,6 +18,22 @@ export const registerInnerUpdates = () => {
       recursiveUnmarkUpdatesForElements(event.target)
     })
   })
+
+  document.addEventListener('turbo-boost:command:start', event => {
+    recursiveMarkUpdatesForElements(event.target)
+  })
+
+  document.addEventListener('turbo-boost:command:finish', event => {
+    setTimeout(() => {
+      recursiveUnmarkUpdatesForElements(event.target)
+    })
+  })
+
+  document.addEventListener('turbo-boost:command:error', event => {
+    setTimeout(() => {
+      recursiveUnmarkUpdatesForElements(event.target)
+    })
+  })
 }
 
 const recursiveMarkUpdatesForElements = leaf => {


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

## Description

This PR adds the TB-Commands events to the `inner-updates-compat` module, because otherwise mutating a model could result in multiple Updates firing the Turbo Boost Commands controller action again.