### PR TITLE
Add setting switch to disable assets compilation

### DIFF
--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -11,7 +11,7 @@ module CableReady
     include Observable
     include Singleton
 
-    attr_accessor :on_failed_sanity_checks, :on_new_version_available
+    attr_accessor :on_failed_sanity_checks, :on_new_version_available, :precompile_assets
     attr_writer :verifier_key
 
     def initialize
@@ -19,6 +19,7 @@ module CableReady
       @operation_names = Set.new(default_operation_names)
       @on_failed_sanity_checks = :exit
       @on_new_version_available = :ignore
+      @precompile_assets = true
     end
 
     def observers

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -2,6 +2,21 @@ require "rails/engine"
 
 module CableReady
   class Engine < Rails::Engine
+    # If you don't want to precompile CableReady's assets (eg. because you're using webpack),
+    # you can do this in an initializer:
+    #
+    # config.after_initialize do
+    #   config.assets.precompile -= CableReady::Engine::PRECOMPILE_ASSETS
+    # end
+    PRECOMPILE_ASSETS = %w[
+      cable_ready.js
+      cable_ready.min.js
+      cable_ready.min.js.map
+      cable_ready.umd.js
+      cable_ready.umd.min.js
+      cable_ready.umd.min.js.map
+    ]
+
     initializer "cable_ready.sanity_check" do
       SanityChecker.check! unless Rails.env.production?
     end
@@ -18,15 +33,8 @@ module CableReady
     end
 
     initializer "cable_ready.assets" do |app|
-      if app.config.respond_to?(:assets)
-        app.config.assets.precompile += %w[
-          cable_ready.js
-          cable_ready.min.js
-          cable_ready.min.js.map
-          cable_ready.umd.js
-          cable_ready.umd.min.js
-          cable_ready.umd.min.js.map
-        ]
+      if app.config.respond_to?(:assets) && CableReady.config.precompile_assets
+        app.config.assets.precompile += PRECOMPILE_ASSETS
       end
     end
 

--- a/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
+++ b/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
@@ -11,6 +11,11 @@ CableReady.configure do |config|
 
   # config.on_new_version_available = :ignore
 
+  # Enable/disable assets compilation
+  # `true` or `false`
+
+  # config.precompile_assets = true
+
   # Define your own custom operations
   # https://cableready.stimulusreflex.com/customization#custom-operations
 


### PR DESCRIPTION
Like ActionCable: https://github.com/rails/rails/blob/main/actioncable/lib/action_cable/engine.rb#L27 

Useful when using Webpacker to manage static assets

- [ ] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
- [ ] This is not a documentation update
