### PR TITLE
Updatable logging

### DIFF
--- a/javascript/debug.js
+++ b/javascript/debug.js
@@ -1,0 +1,19 @@
+let debugging = false
+
+export default {
+  get enabled () {
+    return debugging
+  },
+  get disabled () {
+    return !debugging
+  },
+  get value () {
+    return debugging
+  },
+  set (value) {
+    debugging = !!value
+  },
+  set debug (value) {
+    debugging = !!value
+  }
+}

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -13,9 +13,12 @@ import StreamFromElement from './elements/stream_from_element'
 import UpdatesForElement from './elements/updates_for_element'
 import SubscribingElement from './elements/subscribing_element'
 import CableConsumer from './cable_consumer'
+import Debug from './debug'
 
 const initialize = (initializeOptions = {}) => {
-  const { consumer, onMissingElement } = initializeOptions
+  const { consumer, onMissingElement, debug } = initializeOptions
+
+  Debug.set(!!debug)
 
   if (consumer) {
     CableConsumer.setConsumer(consumer)

--- a/javascript/updatable/log.js
+++ b/javascript/updatable/log.js
@@ -1,0 +1,41 @@
+const request = (data, blocks) => {
+  console.log(
+    `\u2191 Updatable request affecting ${blocks.length} element(s): `,
+    {
+      elements: blocks.map(b => b.element),
+      identifiers: blocks.map(b => b.element.getAttribute('identifier')),
+      data
+    }
+  )
+}
+
+const cancel = (timestamp, reason) => {
+  const duration = new Date() - timestamp
+  console.log(
+    `\u274C Updatable request canceled after ${duration}ms: ${reason}`
+  )
+}
+
+const response = (timestamp, element, urls) => {
+  const duration = new Date() - timestamp
+  console.log(`\u2193 Updatable response: All URLs fetched in ${duration}ms`, {
+    element,
+    urls
+  })
+}
+
+const morphStart = (timestamp, element) => {
+  const duration = new Date() - timestamp
+  console.log(`\u21BB Updatable morph: starting after ${duration}ms`, {
+    element
+  })
+}
+
+const morphEnd = (timestamp, element) => {
+  const duration = new Date() - timestamp
+  console.log(`\u21BA Updatable morph: completed after ${duration}ms`, {
+    element
+  })
+}
+
+export default { request, cancel, response, morphStart, morphEnd }

--- a/javascript/updatable/log.js
+++ b/javascript/updatable/log.js
@@ -1,4 +1,8 @@
+import Debug from '../debug'
+
 const request = (data, blocks) => {
+  if (Debug.disabled) return
+
   console.log(
     `\u2191 Updatable request affecting ${blocks.length} element(s): `,
     {
@@ -10,6 +14,8 @@ const request = (data, blocks) => {
 }
 
 const cancel = (timestamp, reason) => {
+  if (Debug.disabled) return
+
   const duration = new Date() - timestamp
   console.log(
     `\u274C Updatable request canceled after ${duration}ms: ${reason}`
@@ -17,6 +23,8 @@ const cancel = (timestamp, reason) => {
 }
 
 const response = (timestamp, element, urls) => {
+  if (Debug.disabled) return
+
   const duration = new Date() - timestamp
   console.log(`\u2193 Updatable response: All URLs fetched in ${duration}ms`, {
     element,
@@ -25,6 +33,8 @@ const response = (timestamp, element, urls) => {
 }
 
 const morphStart = (timestamp, element) => {
+  if (Debug.disabled) return
+
   const duration = new Date() - timestamp
   console.log(`\u21BB Updatable morph: starting after ${duration}ms`, {
     element
@@ -32,6 +42,8 @@ const morphStart = (timestamp, element) => {
 }
 
 const morphEnd = (timestamp, element) => {
+  if (Debug.disabled) return
+
   const duration = new Date() - timestamp
   console.log(`\u21BA Updatable morph: completed after ${duration}ms`, {
     element


### PR DESCRIPTION
# Enhancement

## Description

Ports over some client side logging functionality from StimulusReflex to better be able to debug and benchmark `Updatable`  interactions.

As in StimulusReflex, logging has to be explicitly enabled by passing `{debug: true}` to `CableReady.initialize`.

Fixes #246

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
