### PR TITLE
Rename `enable_updates` to `enable_cable_ready_updates`

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -15,6 +15,18 @@ module CableReady
         after_commit CollectionUpdatableCallbacks.new(:destroy), on: :destroy
 
         def self.enable_updates(*options)
+          warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` class method will be removed from a future version of CableReady 5"
+
+          enable_cable_ready_updates(*options)
+        end
+
+        def self.skip_updates
+          warn "DEPRECATED: please use `skip_cable_ready_updates` instead. The `skip_updates` class method will be removed from a future version of CableReady 5"
+
+          skip_cable_ready_updates
+        end
+
+        def self.enable_cable_ready_updates(*options)
           options = options.extract_options!
           options = {
             on: [:create, :update, :destroy],
@@ -28,9 +40,9 @@ module CableReady
           after_commit(ModelUpdatableCallbacks.new(:destroy, enabled_operations), {on: :destroy, if: options[:if]})
         end
 
-        def self.skip_updates
+        def self.skip_cable_ready_updates
           skip_updates_classes.push(self)
-          yield
+          yield if block_given?
         ensure
           skip_updates_classes.pop
         end
@@ -41,7 +53,12 @@ module CableReady
 
     module ClassMethods
       def has_many(name, scope = nil, **options, &extension)
-        option = options.delete(:enable_updates)
+        option = if options.has_key?(:enable_updates)
+          warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` option will be removed from a future version of CableReady 5"
+          options.delete(:enable_updates)
+        else
+          options.delete(:enable_cable_ready_updates)
+        end
 
         descendants = options.delete(:descendants)
 
@@ -52,7 +69,12 @@ module CableReady
       end
 
       def has_one(name, scope = nil, **options, &extension)
-        option = options.delete(:enable_updates)
+        option = if options.has_key?(:enable_updates)
+          warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` option will be removed from a future version of CableReady 5"
+          options.delete(:enable_updates)
+        else
+          options.delete(:enable_cable_ready_updates)
+        end
 
         descendants = options.delete(:descendants)
 
@@ -64,7 +86,13 @@ module CableReady
 
       def has_many_attached(name, **options)
         raise("ActiveStorage must be enabled to use has_many_attached") unless defined?(ActiveStorage)
-        option = options.delete(:enable_updates)
+
+        option = if options.has_key?(:enable_updates)
+          warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` option will be removed from a future version of CableReady 5"
+          options.delete(:enable_updates)
+        else
+          options.delete(:enable_cable_ready_updates)
+        end
 
         broadcast = option.present?
         result = super
@@ -143,7 +171,7 @@ module CableReady
         when Proc
           options[:if] = option
         else
-          raise ArgumentError, "Invalid enable_updates option #{option}"
+          raise ArgumentError, "Invalid enable_cable_ready_updates option #{option}"
         end
 
         options

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -14,16 +14,16 @@ module CableReady
         after_commit CollectionUpdatableCallbacks.new(:update), on: :update
         after_commit CollectionUpdatableCallbacks.new(:destroy), on: :destroy
 
-        def self.enable_updates(*options)
+        def self.enable_updates(...)
           warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` class method will be removed from a future version of CableReady 5"
 
-          enable_cable_ready_updates(*options)
+          enable_cable_ready_updates(...)
         end
 
-        def self.skip_updates
+        def self.skip_updates(...)
           warn "DEPRECATED: please use `skip_cable_ready_updates` instead. The `skip_updates` class method will be removed from a future version of CableReady 5"
 
-          skip_cable_ready_updates
+          skip_cable_ready_updates(...)
         end
 
         def self.enable_cable_ready_updates(*options)

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -42,7 +42,7 @@ module CableReady
 
         def self.skip_cable_ready_updates
           skip_updates_classes.push(self)
-          yield if block_given?
+          yield
         ensure
           skip_updates_classes.pop
         end

--- a/test/dummy/app/models/dugong.rb
+++ b/test/dummy/app/models/dugong.rb
@@ -2,5 +2,5 @@
 
 class Dugong < ApplicationRecord
   include CableReady::Updatable
-  has_many_attached :images, enable_updates: true
+  has_many_attached :images, enable_cable_ready_updates: true
 end

--- a/test/dummy/app/models/section.rb
+++ b/test/dummy/app/models/section.rb
@@ -3,9 +3,9 @@
 class Section < ApplicationRecord
   include CableReady::Updatable
 
-  enable_updates if: -> { updates_enabled }
+  enable_cable_ready_updates if: -> { updates_enabled }
 
   attribute :updates_enabled, :boolean, default: false
 
-  has_many :blocks, enable_updates: true, descendants: ["Comment"]
+  has_many :blocks, enable_cable_ready_updates: true, descendants: ["Comment"]
 end

--- a/test/dummy/app/models/supplier.rb
+++ b/test/dummy/app/models/supplier.rb
@@ -2,7 +2,7 @@
 
 class Supplier < ApplicationRecord
   include CableReady::Updatable
-  enable_updates
+  enable_cable_ready_updates
 
-  has_one :account, enable_updates: true
+  has_one :account, enable_cable_ready_updates: true
 end

--- a/test/dummy/app/models/team.rb
+++ b/test/dummy/app/models/team.rb
@@ -2,7 +2,7 @@
 
 class Team < ApplicationRecord
   include CableReady::Updatable
-  enable_updates
+  enable_cable_ready_updates
 
-  has_many :users, enable_updates: true
+  has_many :users, enable_cable_ready_updates: true
 end

--- a/test/dummy/app/models/topic.rb
+++ b/test/dummy/app/models/topic.rb
@@ -2,5 +2,5 @@
 
 class Topic < ApplicationRecord
   include CableReady::Updatable
-  enable_updates on: :create
+  enable_cable_ready_updates on: :create
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -2,8 +2,8 @@
 
 class User < ApplicationRecord
   include CableReady::Updatable
-  enable_updates
+  enable_cable_ready_updates
 
-  has_many :posts, enable_updates: true
+  has_many :posts, enable_cable_ready_updates: true
   belongs_to :team, optional: true, touch: true
 end

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -120,7 +120,7 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
     topic.update(title: "Reactive Rails with CableReady")
   end
 
-  test "respects :if on enable_updates" do
+  test "respects :if on enable_cable_ready_updates" do
     mock_server = mock("server")
 
     ActionCable.stubs(:server).returns(mock_server)
@@ -186,4 +186,41 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
 
     assert section.blocks.count == 2
   end
+
+  # standard:disable Lint/ConstantDefinitionInBlock
+  test "warns about deprecated enable_updates class method" do
+    assert_output(nil, /DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` class method will be removed from a future version of CableReady 5/) do
+      class TestEnableUpdates < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_updates
+      end
+    end
+  end
+
+  test "warns about deprecated skip_updates class method" do
+    assert_output(nil, /DEPRECATED: please use `skip_cable_ready_updates` instead. The `skip_updates` class method will be removed from a future version of CableReady 5/) do
+      class TestSkipUpdates < ActiveRecord::Base
+        include CableReady::Updatable
+
+        skip_updates
+      end
+    end
+  end
+
+  test "warns about deprecated enable_updates option on relation" do
+    assert_output(nil, /DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` option will be removed from a future version of CableReady 5/) do
+      class Something < ActiveRecord::Base
+      end
+
+      class TestEnableUpdatesOption < ActiveRecord::Base
+        include CableReady::Updatable
+
+        enable_cable_ready_updates
+
+        has_many :something, enable_updates: true
+      end
+    end
+  end
+  # standard:enable Lint/ConstantDefinitionInBlock
 end

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -200,13 +200,15 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
 
   test "warns about deprecated skip_updates class method" do
     assert_output(nil, /DEPRECATED: please use `skip_cable_ready_updates` instead. The `skip_updates` class method will be removed from a future version of CableReady 5/) do
-      assert_raises {
-        class TestSkipUpdates < ActiveRecord::Base
-          include CableReady::Updatable
+      class TestSkipUpdates < ActiveRecord::Base
+        include CableReady::Updatable
 
-          skip_updates do
-            raise
-          end
+        enable_cable_ready_updates
+      end
+
+      assert_raises {
+        TestSkipUpdates.skip_updates do
+          raise
         end
       }
     end

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -200,11 +200,15 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
 
   test "warns about deprecated skip_updates class method" do
     assert_output(nil, /DEPRECATED: please use `skip_cable_ready_updates` instead. The `skip_updates` class method will be removed from a future version of CableReady 5/) do
-      class TestSkipUpdates < ActiveRecord::Base
-        include CableReady::Updatable
+      assert_raises {
+        class TestSkipUpdates < ActiveRecord::Base
+          include CableReady::Updatable
 
-        skip_updates
-      end
+          skip_updates do
+            raise
+          end
+        end
+      }
     end
   end
 


### PR DESCRIPTION
# Type of PR

Enforcement of Consistency 

## Description

This pull request renames the two class methods and relation options related to the `CableReady::Updatable` module:
* option `enable_updates` to `enable_cable_ready_updates`
* class method `enable_updates` to `enable_cable_ready_updates`
* class method `skip_updates` to `skip_cable_ready_updates`

## Why should this be added

The class methods were super generic and didn't indicate that they were originating from CableReady. The method names were also more likely to clash with other upcoming gems which would port this behavior to a Turbo-related project.

## Migration

All of the deprecated methods and the options emit a warning if they are used so people know how to migrate them. 

#### `enable_updates` relation option
```diff
class Post < ApplicationRecord
  include CableReady::Updatable

- has_many :users, enable_updates: true
+ has_many :users, enable_cable_ready_updates: true
end
```

#### `enable_updates` class method
```diff
class Post < ApplicationRecord
  include CableReady::Updatable

- enable_updates
+ enable_cable_ready_updates
end
```

#### `skip_updates` class method
```diff
-Post.skip_updates do
+Post.skip_cable_ready_updates do
  # do something without broadcasting updates
end
```
## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
