### PR TITLE
Scope CableReady custom HTML elements and view helpers

### DIFF
--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -6,7 +6,7 @@ module CableReady
     include CableReady::StreamIdentifier
 
     def stream_from(*keys, html_options: {})
-      tag.stream_from(**build_options(*keys, html_options))
+      tag.cable_ready_stream_from(**build_options(*keys, html_options))
     end
 
     def updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, html_options: {}, &block)
@@ -15,7 +15,7 @@ module CableReady
       options[:debounce] = debounce if debounce
       options[:only] = only if only
       options[:"ignore-inner-updates"] = "" if ignore_inner_updates
-      tag.updates_for(**options) { capture(&block) }
+      tag.cable_ready_updates_for(**options) { capture(&block) }
     end
 
     def updates_for_if(condition, *keys, **options, &block)

--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -5,11 +5,29 @@ module CableReady
     include CableReady::Compoundable
     include CableReady::StreamIdentifier
 
-    def stream_from(*keys, html_options: {})
+    def stream_from(...)
+      warn "DEPRECATED: please use `cable_ready_stream_from` instead. The `stream_from` view helper will be removed from a future version of CableReady 5"
+
+      cable_ready_stream_from(...)
+    end
+
+    def updates_for(...)
+      warn "DEPRECATED: please use `cable_ready_updates_for` instead. The `updates_for` view helper will be removed from a future version of CableReady 5"
+
+      cable_ready_updates_for(...)
+    end
+
+    def updates_for_if(...)
+      warn "DEPRECATED: please use `cable_ready_updates_for_if` instead. The `updates_for_if` view helper will be removed from a future version of CableReady 5"
+
+      cable_ready_updates_for_if(...)
+    end
+
+    def cable_ready_stream_from(*keys, html_options: {})
       tag.cable_ready_stream_from(**build_options(*keys, html_options))
     end
 
-    def updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, html_options: {}, &block)
+    def cable_ready_updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, html_options: {}, &block)
       options = build_options(*keys, html_options)
       options[:url] = url if url
       options[:debounce] = debounce if debounce
@@ -18,9 +36,9 @@ module CableReady
       tag.cable_ready_updates_for(**options) { capture(&block) }
     end
 
-    def updates_for_if(condition, *keys, **options, &block)
+    def cable_ready_updates_for_if(condition, *keys, **options, &block)
       if condition
-        updates_for(*keys, **options, &block)
+        cable_ready_updates_for(*keys, **options, &block)
       else
         capture(&block)
       end

--- a/javascript/elements/stream_from_element.js
+++ b/javascript/elements/stream_from_element.js
@@ -21,7 +21,7 @@ export default class StreamFromElement extends SubscribingElement {
       )
     } else {
       console.error(
-        'The `stream_from` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
+        'The `cable_ready_stream_from` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
       )
     }
   }

--- a/javascript/elements/stream_from_element.js
+++ b/javascript/elements/stream_from_element.js
@@ -5,8 +5,8 @@ import MissingElement from '../missing_element'
 
 export default class StreamFromElement extends SubscribingElement {
   static define () {
-    if (!customElements.get('stream-from')) {
-      customElements.define('stream-from', this)
+    if (!customElements.get('cable-ready-stream-from')) {
+      customElements.define('cable-ready-stream-from', this)
     }
   }
 

--- a/javascript/elements/stream_from_element.js
+++ b/javascript/elements/stream_from_element.js
@@ -4,10 +4,8 @@ import CableConsumer from '../cable_consumer'
 import MissingElement from '../missing_element'
 
 export default class StreamFromElement extends SubscribingElement {
-  static define () {
-    if (!customElements.get('cable-ready-stream-from')) {
-      customElements.define('cable-ready-stream-from', this)
-    }
+  static get tagName () {
+    return 'cable-ready-stream-from'
   }
 
   async connectedCallback () {

--- a/javascript/elements/subscribing_element.js
+++ b/javascript/elements/subscribing_element.js
@@ -1,4 +1,14 @@
 export default class SubscribingElement extends HTMLElement {
+  static get tagName () {
+    throw new Error('Implement the tagName() getter in the inheriting class')
+  }
+
+  static define () {
+    if (!customElements.get(this.tagName)) {
+      customElements.define(this.tagName, this)
+    }
+  }
+
   disconnectedCallback () {
     if (this.channel) this.channel.unsubscribe()
   }

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -44,7 +44,7 @@ export default class UpdatesForElement extends SubscribingElement {
       this.createSubscription(consumer, 'CableReady::Stream', this.update)
     } else {
       console.error(
-        'The `updates_for` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
+        'The `cable_ready_updates_for` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
       )
     }
   }

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -24,10 +24,8 @@ function url (element) {
 }
 
 export default class UpdatesForElement extends SubscribingElement {
-  static define () {
-    if (!customElements.get('cable-ready-updates-for')) {
-      customElements.define('cable-ready-updates-for', this)
-    }
+  static get tagName () {
+    return 'cable-ready-updates-for'
   }
 
   constructor () {
@@ -46,7 +44,7 @@ export default class UpdatesForElement extends SubscribingElement {
       this.createSubscription(consumer, 'CableReady::Stream', this.update)
     } else {
       console.error(
-        'The `updates-for` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
+        'The `updates_for` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
       )
     }
   }
@@ -109,7 +107,7 @@ export default class UpdatesForElement extends SubscribingElement {
   }
 
   get query () {
-    return `updates-for[identifier="${this.identifier}"]`
+    return `${this.tagName}[identifier="${this.identifier}"]`
   }
 
   get identifier () {

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -25,8 +25,8 @@ function url (element) {
 
 export default class UpdatesForElement extends SubscribingElement {
   static define () {
-    if (!customElements.get('updates-for')) {
-      customElements.define('updates-for', this)
+    if (!customElements.get('cable-ready-updates-for')) {
+      customElements.define('cable-ready-updates-for', this)
     }
   }
 

--- a/test/lib/cable_ready/view_helper_test.rb
+++ b/test/lib/cable_ready/view_helper_test.rb
@@ -8,11 +8,11 @@ class CableReady::ViewHelperTest < ActionView::TestCase
   test "renders <cable-ready-stream-from> element" do
     expected = %(<cable-ready-stream-from identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-stream-from>)
 
-    assert_dom_equal expected, stream_from("key")
+    assert_dom_equal expected, cable_ready_stream_from("key")
   end
 
   test "stream_from renders html options" do
-    fragment = Nokogiri::HTML.fragment(stream_from("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+    fragment = Nokogiri::HTML.fragment(cable_ready_stream_from("key", html_options: {class: "block", data: {controller: "modal"}}) {})
     element = fragment.children.first
 
     assert_equal "cable-ready-stream-from", element.name
@@ -25,11 +25,11 @@ class CableReady::ViewHelperTest < ActionView::TestCase
   test "renders <cable-ready-updates-for> element" do
     expected = %(<cable-ready-updates-for identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-updates-for>)
 
-    assert_dom_equal expected, updates_for("key") {}
+    assert_dom_equal expected, cable_ready_updates_for("key") {}
   end
 
   test "updates_for renders html options" do
-    fragment = Nokogiri::HTML.fragment(updates_for("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+    fragment = Nokogiri::HTML.fragment(cable_ready_updates_for("key", html_options: {class: "block", data: {controller: "modal"}}) {})
     element = fragment.children.first
 
     assert_equal "cable-ready-updates-for", element.name
@@ -40,7 +40,7 @@ class CableReady::ViewHelperTest < ActionView::TestCase
   # conditional updates_for
 
   test "updates_for_if renders if condition is met" do
-    fragment = Nokogiri::HTML.fragment(updates_for_if(true, "key") { tag.div })
+    fragment = Nokogiri::HTML.fragment(cable_ready_updates_for_if(true, "key") { tag.div })
     element = fragment.children.first
 
     assert_equal "cable-ready-updates-for", element.name
@@ -48,7 +48,7 @@ class CableReady::ViewHelperTest < ActionView::TestCase
   end
 
   test "updates_for_if doesn't render if condition isn't met" do
-    fragment = Nokogiri::HTML.fragment(updates_for_if(false, "key") { tag.div })
+    fragment = Nokogiri::HTML.fragment(cable_ready_updates_for_if(false, "key") { tag.div })
     element = fragment.children.first
 
     refute_equal "cable-ready-updates-for", element.name
@@ -65,6 +65,32 @@ class CableReady::ViewHelperTest < ActionView::TestCase
     end
 
     assert_equal "`CableReadyHelper` was renamed to `CableReady::ViewHelper`", expection.message
+  end
+
+  # deprecation warnings
+
+  test "updates_for deprecation warning" do
+    assert_output(nil, /DEPRECATED: please use `cable_ready_updates_for` instead. The `updates_for` view helper will be removed from a future version of CableReady 5/) do
+      expected = %(<cable-ready-updates-for identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-stream-from>)
+
+      assert_dom_equal expected, updates_for("key") {}
+    end
+  end
+
+  test "updates_for_if deprecation warning" do
+    assert_output(nil, /DEPRECATED: please use `cable_ready_updates_for_if` instead. The `updates_for_if` view helper will be removed from a future version of CableReady 5/) do
+      expected = %(<cable-ready-updates-for identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-stream-from>)
+
+      assert_dom_equal expected, updates_for_if(true, "key") {}
+    end
+  end
+
+  test "stream_from deprecation warning" do
+    assert_output(nil, /DEPRECATED: please use `cable_ready_stream_from` instead. The `stream_from` view helper will be removed from a future version of CableReady 5/) do
+      expected = %(<cable-ready-stream-from identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-stream-from>)
+
+      assert_dom_equal expected, stream_from("key")
+    end
   end
 
   # ensure dom_id emits no #s

--- a/test/lib/cable_ready/view_helper_test.rb
+++ b/test/lib/cable_ready/view_helper_test.rb
@@ -5,36 +5,54 @@ require "test_helper"
 class CableReady::ViewHelperTest < ActionView::TestCase
   # stream_from
 
-  test "stream_from renders html options" do
-    element = Nokogiri::HTML.fragment(stream_from("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+  test "renders <cable-ready-stream-from> element" do
+    expected = %(<cable-ready-stream-from identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-stream-from>)
 
-    assert_equal "block", element.children.first["class"]
-    assert_equal "modal", element.children.first["data-controller"]
+    assert_dom_equal expected, stream_from("key")
+  end
+
+  test "stream_from renders html options" do
+    fragment = Nokogiri::HTML.fragment(stream_from("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+    element = fragment.children.first
+
+    assert_equal "cable-ready-stream-from", element.name
+    assert_equal "block", element["class"]
+    assert_equal "modal", element["data-controller"]
   end
 
   # updates_for
 
-  test "updates_for renders html options" do
-    element = Nokogiri::HTML.fragment(updates_for("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+  test "renders <cable-ready-updates-for> element" do
+    expected = %(<cable-ready-updates-for identifier="ImtleSI=--e3efcba75b971eb15fa7fcc579a16c2b7a3734081bf7dbbace7240ebfbda078d"></cable-ready-updates-for>)
 
-    assert_equal "block", element.children.first["class"]
-    assert_equal "modal", element.children.first["data-controller"]
+    assert_dom_equal expected, updates_for("key") {}
+  end
+
+  test "updates_for renders html options" do
+    fragment = Nokogiri::HTML.fragment(updates_for("key", html_options: {class: "block", data: {controller: "modal"}}) {})
+    element = fragment.children.first
+
+    assert_equal "cable-ready-updates-for", element.name
+    assert_equal "block", element["class"]
+    assert_equal "modal", element["data-controller"]
   end
 
   # conditional updates_for
 
   test "updates_for_if renders if condition is met" do
-    element = Nokogiri::HTML.fragment(updates_for_if(true, "key") { tag.div })
+    fragment = Nokogiri::HTML.fragment(updates_for_if(true, "key") { tag.div })
+    element = fragment.children.first
 
-    assert_equal "updates-for", element.children.first.name
-    refute_equal "div", element.children.first.name
+    assert_equal "cable-ready-updates-for", element.name
+    refute_equal "div", element.name
   end
 
   test "updates_for_if doesn't render if condition isn't met" do
-    element = Nokogiri::HTML.fragment(updates_for_if(false, "key") { tag.div })
+    fragment = Nokogiri::HTML.fragment(updates_for_if(false, "key") { tag.div })
+    element = fragment.children.first
 
-    refute_equal "updates-for", element.children.first.name
-    assert_equal "div", element.children.first.name
+    refute_equal "cable-ready-updates-for", element.name
+    assert_equal "div", element.name
   end
 
   test "raises when including CableReadyHelper" do


### PR DESCRIPTION
# Type of PR

Consistency Enforcement

## Description

Similarly to #250 this pull requests scopes the custom HTML elements and view helpers with the `cable_ready` name.

#### Custom Elements:

* `<stream-from>` -> `<cable-ready-stream-from>`
* `<updates-for>` -> `<cable-ready-updates-for>`

There's nothing to migrate here, since those element names were just used under the hood.

#### `CableReady::ViewHelper` view helpers

* `stream_from` -> `cable_ready_stream_from`
  ```diff
  -<%= stream_from Photo %>
  +<%= cable_ready_stream_from Photo %>
  ```

* `updates_for` -> `cable_ready_updates_for`

  ```diff
  -<%= updates_for @feed, :comments do %>
  +<%= cable_ready_updates_for @feed, :comments do %>
    <%= render @feed.comments %>
  <% end %>
  ```


* `updates_for_if` -> `cable_ready_updates_for_if`

  ```diff
  -<%= updates_for_if @feed.updates?, @feed, :comments do %>
  +<%= cable_ready_updates_for_if @feed.updates?, @feed, :comments do %>
    <%= render @feed.comments %>
  <% end %>
  ```

## Why should this be added

The names are super generic and didn't indicate that they were originating from CableReady. Especially the `stream_from` is very confusing, because ActionCable also uses such method.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
