### PR TITLE
fix: dom_id from view helper

### DIFF
--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -4,7 +4,6 @@ module CableReady
   module ViewHelper
     include CableReady::Compoundable
     include CableReady::StreamIdentifier
-    include CableReady::Broadcaster
 
     def stream_from(*keys, html_options: {})
       tag.stream_from(**build_options(*keys, html_options))
@@ -25,6 +24,10 @@ module CableReady
       else
         capture(&block)
       end
+    end
+
+    def cable_car
+      CableReady::CableCar.instance
     end
 
     private

--- a/test/lib/cable_ready/view_helper_test.rb
+++ b/test/lib/cable_ready/view_helper_test.rb
@@ -3,8 +3,6 @@
 require "test_helper"
 
 class CableReady::ViewHelperTest < ActionView::TestCase
-  include CableReady::Broadcaster
-
   # stream_from
 
   test "stream_from renders html options" do
@@ -49,5 +47,11 @@ class CableReady::ViewHelperTest < ActionView::TestCase
     end
 
     assert_equal "`CableReadyHelper` was renamed to `CableReady::ViewHelper`", expection.message
+  end
+
+  # ensure dom_id emits no #s
+
+  test "emits the correct dom_id" do
+    assert_equal "new_post", dom_id(Post.new)
   end
 end


### PR DESCRIPTION
# Bug Fix

## Description

Fixes the broken `dom_id` helper that was cause by `ViewHelper` including `Broadcaster`, which in turn included `Identifiable`, which contains a patched version of dom_id

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
