### PR TITLE
Don't raise when including `CableReadyHelper`

### DIFF
--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -2,7 +2,6 @@
 
 require "open-uri"
 require "active_support/message_verifier"
-require "cable_ready_helper"
 require "cable_ready/identifiable"
 require "cable_ready/operation_builder"
 require "cable_ready/config"
@@ -15,6 +14,7 @@ require "cable_ready/channels"
 require "cable_ready/cable_car"
 require "cable_ready/stream_identifier"
 require "cable_ready/version"
+require "cable_ready_helper"
 
 module CableReady
   class << self

--- a/lib/cable_ready_helper.rb
+++ b/lib/cable_ready_helper.rb
@@ -2,8 +2,12 @@
 
 # TODO: remove me once CableReady 5.0 was released
 
+require_relative "../app/helpers/cable_ready/view_helper"
+
 module CableReadyHelper
   def self.included(base)
-    raise "`CableReadyHelper` was renamed to `CableReady::ViewHelper`"
+    warn "NOTICE: `CableReadyHelper` was renamed to `CableReady::ViewHelper`. Please update your include accordingly."
+
+    include ::CableReady::ViewHelper
   end
 end

--- a/lib/cable_ready_helper.rb
+++ b/lib/cable_ready_helper.rb
@@ -8,6 +8,6 @@ module CableReadyHelper
   def self.included(base)
     warn "NOTICE: `CableReadyHelper` was renamed to `CableReady::ViewHelper`. Please update your include accordingly."
 
-    include ::CableReady::ViewHelper
+    base.include(::CableReady::ViewHelper)
   end
 end

--- a/test/lib/cable_ready/view_helper_test.rb
+++ b/test/lib/cable_ready/view_helper_test.rb
@@ -37,17 +37,18 @@ class CableReady::ViewHelperTest < ActionView::TestCase
     assert_equal "div", element.children.first.name
   end
 
-  test "raises when including CableReadyHelper" do
-    expection = assert_raises do
-      class RaiseHelperTest # standard:disable Lint/ConstantDefinitionInBlock
+  # standard:disable Lint/ConstantDefinitionInBlock
+  test "prints warning when including CableReadyHelper" do
+    assert_output(nil, %(NOTICE: `CableReadyHelper` was renamed to `CableReady::ViewHelper`. Please update your include accordingly.\n)) do
+      class CableReadyHelperTest
         include ::CableReadyHelper
       end
 
-      RaiseHelperTest.new
+      assert_includes CableReadyHelperTest, ::CableReadyHelper
+      assert_includes CableReadyHelperTest, ::CableReady::ViewHelper
     end
-
-    assert_equal "`CableReadyHelper` was renamed to `CableReady::ViewHelper`", expection.message
   end
+  # standard:enable Lint/ConstantDefinitionInBlock
 
   # ensure dom_id emits no #s
 


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Instead of raising an exception when including the `CableReadyHelper` module we print a warning and include the right `CableReady::ViewHelper` module anyway, so we are not breaking any existing code.

## Why should this be added

This is a much better DX than raising an error and requiring the developer to fix it right away. 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
