### PR TITLE
Fix link to StimulusReflex authentication guide

### DIFF
--- a/docs/guide/action-cable.md
+++ b/docs/guide/action-cable.md
@@ -20,7 +20,7 @@ To double-murder a metaphor, Channels are to classes what Subscriptions are to i
 
 ## Connection authentication
 
-Since it's difficult to improve upon perfection, please consult the StimulusReflex documentation section on [authenticating users in ActionCable](https://docs.stimulusreflex.com/authentication).
+Since it's difficult to improve upon perfection, please consult the StimulusReflex documentation section on [authenticating users in ActionCable](https://docs.stimulusreflex.com/guide/authentication.html).
 
 ## Send data to any ActionCable Channel
 


### PR DESCRIPTION
# documentation fix

## Description

ActionCable guide page had old reference to StimulusReflect authentication guide

## Why should this be added

Fixes invalid link

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
