### PR TITLE
Namespace Broadcastjob

### DIFF
--- a/app/jobs/cable_ready/broadcast_job.rb
+++ b/app/jobs/cable_ready/broadcast_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 if defined?(ActiveJob::Base)
-  class CableReadyBroadcastJob < ActiveJob::Base
+  class CableReady::BroadcastJob < ActiveJob::Base
     include CableReady::Broadcaster
 
     def perform(identifier:, operations:, model: nil)

--- a/lib/cable_ready/channel.rb
+++ b/lib/cable_ready/channel.rb
@@ -28,7 +28,7 @@ module CableReady
 
     def broadcast_later(clear: true, queue: nil)
       raise("Action Cable must be enabled to use broadcast_later") unless defined?(ActionCable)
-      CableReadyBroadcastJob
+      CableReady::BroadcastJob
         .set(queue: queue ? queue.to_sym : CableReady.config.broadcast_job_queue)
         .perform_later(identifier: identifier, operations: operations_payload)
       reset! if clear
@@ -36,7 +36,7 @@ module CableReady
 
     def broadcast_later_to(model, clear: true, queue: nil)
       raise("Action Cable must be enabled to use broadcast_later_to") unless defined?(ActionCable)
-      CableReadyBroadcastJob
+      CableReady::BroadcastJob
         .set(queue: queue ? queue.to_sym : CableReady.config.broadcast_job_queue)
         .perform_later(identifier: identifier.name, operations: operations_payload, model: model)
       reset! if clear


### PR DESCRIPTION
# Enhancement

## Description

Puts the `BroadcastJob` in the `CableReady` namespace.

## Why should this be added

To line it up with all the other modules.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
