### PR TITLE
Rework CableReady's `ActionController::Renderers`

### DIFF
--- a/docs/guide/cable-car.md
+++ b/docs/guide/cable-car.md
@@ -52,8 +52,10 @@ One of the most exciting possibilities for Cable Car is to send operations in re
 
 ```ruby
 class HomeController < ApplicationController
+  include CableReady::Broadcaster
+
   def index
-    render operations: cable_car.console_log(message: "hi")
+    render cable_ready: cable_car.console_log(message: "hi")
   end
 end
 ```
@@ -106,7 +108,7 @@ class HomeController < ApplicationController
   include CableReady::Broadcaster
 
   def ride
-    render operations: cable_car.inner_html("#users", html: "<span>winning</span>")
+    render cable_ready: cable_car.inner_html("#users", html: "<span>winning</span>")
   end
 end
 ```

--- a/docs/guide/cableready-everywhere.md
+++ b/docs/guide/cableready-everywhere.md
@@ -75,8 +75,10 @@ patch 'users/:id/message', to: 'users#message'
 
 ```ruby [app/controllers/users_controller.rb]
 class UsersController < ApplicationController
+  include CableReady::Broadcaster
+
   def message
-    render operations: cable_car.console_log(message: "Hi!")
+    render cable_ready: cable_car.console_log(message: "Hi!")
   end
 end
 ```

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -41,16 +41,15 @@ module CableReady
           response.content_type ||= Mime[:cable_ready]
           response.headers["X-Cable-Ready-Version"] = CableReady::VERSION
 
-          render json: operations.dispatch
+          render json: operations.respond_to?(:dispatch) ? operations.dispatch : operations
         end
 
         ActionController::Renderers.add :cable_ready do |operations, options|
           response.content_type ||= Mime[:cable_ready]
           response.headers["X-Cable-Ready-Version"] = CableReady::VERSION
 
-          render json: operations.dispatch
+          render json: operations.respond_to?(:dispatch) ? operations.dispatch : operations
         end
-
       end
     end
 

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -39,11 +39,15 @@ module CableReady
           warn "DEPRECATED: CableReady's `render operations:` call has been renamed to `render cable_ready:`. Please update your render call."
 
           response.content_type ||= Mime[:cable_ready]
+          response.headers["X-Cable-Ready-Version"] = CableReady::VERSION
+
           render json: operations.dispatch
         end
 
         ActionController::Renderers.add :cable_ready do |operations, options|
           response.content_type ||= Mime[:cable_ready]
+          response.headers["X-Cable-Ready-Version"] = CableReady::VERSION
+
           render json: operations.dispatch
         end
 

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -32,6 +32,13 @@ module CableReady
     initializer "cable_ready.renderer" do
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :operations do |operations, options|
+          warn "DEPRECATED: CableReady's `render operations:` call has been renamed to `render cable_ready:`. Please update your render call."
+
+          response.content_type ||= Mime[:cable_ready]
+          render json: operations.dispatch
+        end
+
+        ActionController::Renderers.add :cable_ready do |operations, options|
           response.content_type ||= Mime[:cable_ready]
           render json: operations.dispatch
         end

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -29,6 +29,10 @@ module CableReady
       SanityChecker.check! unless Rails.env.production?
     end
 
+    initializer "cable_ready.mimetype" do
+      Mime::Type.register "text/vnd.cable-ready.json", :cable_ready
+    end
+
     initializer "cable_ready.renderer" do
       ActiveSupport.on_load(:action_controller) do
         ActionController::Renderers.add :operations do |operations, options|
@@ -43,7 +47,6 @@ module CableReady
           render json: operations.dispatch
         end
 
-        Mime::Type.register "application/vnd.cable-ready.json", :cable_ready
       end
     end
 


### PR DESCRIPTION
# Type of PR

Deprecation + Enhancement

## Description

CableReady's `render operations:` ActionController renderer doesn't indicate that it's coming/being used for CableReady operations. This pull request renames the renderer to `render cable_ready:` and adds a deprecation warning for the `operations` renderer.

Additionally it make the DX around it a little bit better by checking if the passed argument responds to `.dispatch` before calling it. This helps when you already called `.dispatch` in the controller action or if you provide it a already converted JSON string.

This pull request also changes the `cable_ready` MIME type from `application/vnd.cable-ready.json` to `text/vnd.cable-ready.json` so that the response from a controller action can be viewed in a browser.

Finally, this pull request adds the `X-Cable-Ready-Version` header to the response. 

![Screenshot 2023-03-04 at 14 11 07](https://user-images.githubusercontent.com/6411752/222904301-1f450771-b8c3-47c6-aaf0-466b0ca9229e.png)

## Why should this be added

This is an effort to keep the naming consistent and scope all CableReady functions with its own name. Following up on #259, #252 and #250.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
