### PR TITLE
Debounced updatable

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -206,21 +206,23 @@ module CableReady
         return if skip_updates_classes.any? { |klass| klass >= self }
         raise("ActionCable must be enabled to use Updatable") unless defined?(ActionCable)
 
-        @debounce_time ||= 0.seconds
-
-        if @debounce_time > 0.seconds
+        if debounce_time > 0.seconds
           key = compound([model_class, *options])
           old_wait_until = CableReady::Updatable.debounce_adapter[key]
           now = Time.now.to_f
 
           if old_wait_until.nil? || old_wait_until < now
-            new_wait_until = now + @debounce_time.to_f
+            new_wait_until = now + debounce_time.to_f
             CableReady::Updatable.debounce_adapter[key] = new_wait_until
             ActionCable.server.broadcast(model_class, options)
           end
         else
           ActionCable.server.broadcast(model_class, options)
         end
+      end
+
+      def debounce_time
+        @debounce_time ||= 0.seconds
       end
 
       def skip_updates_classes

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -8,11 +8,19 @@ module CableReady
 
     class MemoryDebounceAdapter
       include Singleton
+      include MonitorMixin
 
-      delegate_missing_to :@keys
+      delegate_missing_to :@dict
 
       def initialize
-        @keys = {}
+        super
+        @dict = {}
+      end
+
+      def []=(key, value)
+        synchronize do
+          @dict[key] = value
+        end
       end
     end
 

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -22,6 +22,12 @@ module CableReady
           @dict[key] = value
         end
       end
+
+      def [](key)
+        synchronize do
+          @dict[key]
+        end
+      end
     end
 
     mattr_accessor :debounce_adapter, default: MemoryDebounceAdapter.instance

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -6,6 +6,18 @@ module CableReady
   module Updatable
     extend ::ActiveSupport::Concern
 
+    class MemoryDebounceAdapter
+      include Singleton
+
+      delegate_missing_to :@keys
+
+      def initialize
+        @keys = {}
+      end
+    end
+
+    mattr_accessor :debounce_adapter, default: MemoryDebounceAdapter.instance
+
     included do |base|
       if defined?(ActiveRecord) && base < ActiveRecord::Base
         include ExtendHasMany
@@ -30,10 +42,13 @@ module CableReady
           options = options.extract_options!
           options = {
             on: [:create, :update, :destroy],
-            if: -> { true }
+            if: -> { true },
+            debounce: 0.seconds
           }.merge(options)
 
           enabled_operations = Array(options[:on])
+
+          @debounce_time = options[:debounce]
 
           after_commit(ModelUpdatableCallbacks.new(:create, enabled_operations), {on: :create, if: options[:if]})
           after_commit(ModelUpdatableCallbacks.new(:update, enabled_operations), {on: :update, if: options[:if]})
@@ -52,6 +67,8 @@ module CableReady
     private
 
     module ClassMethods
+      include Compoundable
+
       def has_many(name, scope = nil, **options, &extension)
         option = if options.has_key?(:enable_updates)
           warn "DEPRECATED: please use `enable_cable_ready_updates` instead. The `enable_updates` option will be removed from a future version of CableReady 5"
@@ -180,7 +197,22 @@ module CableReady
       def broadcast_updates(model_class, options)
         return if skip_updates_classes.any? { |klass| klass >= self }
         raise("ActionCable must be enabled to use Updatable") unless defined?(ActionCable)
-        ActionCable.server.broadcast(model_class, options)
+
+        @debounce_time ||= 0.seconds
+
+        if @debounce_time > 0.seconds
+          key = compound([model_class, *options])
+          old_wait_until = CableReady::Updatable.debounce_adapter[key]
+          now = Time.now.to_f
+
+          if old_wait_until.nil? || old_wait_until < now
+            new_wait_until = now + @debounce_time.to_f
+            CableReady::Updatable.debounce_adapter[key] = new_wait_until
+            ActionCable.server.broadcast(model_class, options)
+          end
+        else
+          ActionCable.server.broadcast(model_class, options)
+        end
       end
 
       def skip_updates_classes

--- a/test/dummy/app/models/site.rb
+++ b/test/dummy/app/models/site.rb
@@ -1,0 +1,5 @@
+class Site < ApplicationRecord
+  include CableReady::Updatable
+
+  enable_cable_ready_updates
+end

--- a/test/dummy/app/models/site.rb
+++ b/test/dummy/app/models/site.rb
@@ -1,5 +1,5 @@
 class Site < ApplicationRecord
   include CableReady::Updatable
 
-  enable_cable_ready_updates
+  enable_cable_ready_updates debounce: 3.seconds
 end

--- a/test/dummy/db/migrate/20230301080311_create_sites.rb
+++ b/test/dummy/db/migrate/20230301080311_create_sites.rb
@@ -1,0 +1,9 @@
+class CreateSites < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sites do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_072701) do
+ActiveRecord::Schema.define(version: 2023_03_01_080311) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "account_number"
@@ -74,6 +72,12 @@ ActiveRecord::Schema.define(version: 2022_05_18_072701) do
 
   create_table "sections", force: :cascade do |t|
     t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "sites", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/dummy/test/fixtures/sites.yml
+++ b/test/dummy/test/fixtures/sites.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+
+two:
+  name: MyString

--- a/test/dummy/test/models/site_test.rb
+++ b/test/dummy/test/models/site_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SiteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -229,4 +229,21 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
     end
   end
   # standard:enable Lint/ConstantDefinitionInBlock
+
+  test "only sends out a ping once per debounce period" do
+    site = Site.create(name: "Front Page")
+
+    mock_server = mock("server")
+    mock_server.expects(:broadcast).with(Site, {changed: ["name", "updated_at"]}).twice
+    mock_server.expects(:broadcast).with(site.to_global_id, {changed: ["name", "updated_at"]}).twice
+
+    ActionCable.stubs(:server).returns(mock_server)
+
+    # debounce time is 3 seconds, so the last update should trigger its own broadcast
+    site.update(name: "Landing Page 1")
+    travel(1.second)
+    site.update(name: "Landing Page 2")
+    travel(3.seconds)
+    site.update(name: "Landing Page 3")
+  end
 end


### PR DESCRIPTION
# Enhancement

## Description

One of the big downsides of using `CableReady::Updatable` in the wild is that it can lead to a lot of noise on the ActionCable connection. This is because every change on a model that enables updates leads to a ping being sent over ActionCable due to the usage of ActiveRecord callbacks.

This PR introduces a `debounce:` option that takes an `ActiveSupport::Duration` argument that will only send out one ping for this model per debounce period.

It makes use of a simple internal per-process `MemoryDebounceAdapter`, which is just a thin synchronized layer around a `Hash`.

Preparations are made, however, to override this adapter using a `CableReady::Updatable.debounce_adapter` mattr_accessor, which can be overridden in an initializer. This should make it possible to devise other adapters (for example based on DRb or Layered Caching) in the future.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
