### PR TITLE
Fix inverse of resolution

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -112,26 +112,16 @@ module CableReady
       def enrich_association_with_updates(name, option, descendants = nil)
         reflection = reflect_on_association(name)
 
-        inverse_of = reflection.inverse_of&.name&.to_s
-        through_association = nil
-
-        if reflection.through_reflection?
-          inverse_of = reflection.through_reflection.inverse_of&.name&.to_s
-          through_association = reflection.through_reflection.name.to_s.singularize
-        end
-
         options = build_options(option)
 
         [reflection.klass, *descendants&.map(&:to_s)&.map(&:constantize)].each do |klass|
           klass.send(:include, CableReady::Updatable) unless klass.respond_to?(:cable_ready_collections)
-          klass.cable_ready_collections.register({
+          klass.cable_ready_collections.register(Collection.new(
             klass: self,
-            foreign_key: reflection.foreign_key,
             name: name,
-            inverse_association: inverse_of,
-            through_association: through_association,
-            options: options
-          })
+            options: options,
+            reflection: reflection
+          ))
         end
       end
 
@@ -140,14 +130,14 @@ module CableReady
 
         ActiveStorage::Attachment.send(:include, CableReady::Updatable) unless ActiveStorage::Attachment.respond_to?(:cable_ready_collections)
 
-        ActiveStorage::Attachment.cable_ready_collections.register({
+        ActiveStorage::Attachment.cable_ready_collections.register(Collection.new(
           klass: self,
           foreign_key: "record_id",
           name: name,
           inverse_association: "record",
           through_association: nil,
           options: options
-        })
+        ))
       end
 
       def build_options(option)

--- a/app/models/concerns/cable_ready/updatable/collections_registry.rb
+++ b/app/models/concerns/cable_ready/updatable/collections_registry.rb
@@ -37,14 +37,14 @@ module CableReady
       def find_resource_for_update(collection, model)
         collection.reflection ||= collection.klass.reflect_on_association(collection.name)
 
-        collection.foreign_key ||= collection.reflection.foreign_key
+        collection.foreign_key ||= collection.reflection&.foreign_key
 
         # lazy load and store through and inverse associations
         if collection.reflection&.through_reflection?
-          collection.inverse_association ||= collection.reflection.through_reflection.inverse_of&.name&.to_s
-          collection.through_association = collection.reflection.through_reflection.name.to_s.singularize
+          collection.inverse_association ||= collection.reflection&.through_reflection.inverse_of&.name&.to_s
+          collection.through_association = collection.reflection&.through_reflection.name.to_s.singularize
         else
-          collection.inverse_association ||= collection.reflection.inverse_of&.name&.to_s
+          collection.inverse_association ||= collection.reflection&.inverse_of&.name&.to_s
         end
 
         raise ArgumentError, "Could not find inverse_of for #{collection.name}" unless collection.inverse_association

--- a/app/models/concerns/cable_ready/updatable/collections_registry.rb
+++ b/app/models/concerns/cable_ready/updatable/collections_registry.rb
@@ -2,6 +2,17 @@
 
 module CableReady
   module Updatable
+    Collection = Struct.new(
+      :klass,
+      :name,
+      :reflection,
+      :options,
+      :foreign_key,
+      :inverse_association,
+      :through_association,
+      keyword_init: true
+    )
+
     class CollectionsRegistry
       def initialize
         @registered_collections = []
@@ -12,23 +23,35 @@ module CableReady
       end
 
       def broadcast_for!(model, operation)
-        @registered_collections.select { |c| c[:options][:on].include?(operation) }
+        @registered_collections.select { |c| c.options[:on].include?(operation) }
           .each do |collection|
           resource = find_resource_for_update(collection, model)
           next if resource.nil?
 
-          collection[:klass].cable_ready_update_collection(resource, collection[:name], model) if collection[:options][:if].call(resource)
+          collection.klass.cable_ready_update_collection(resource, collection.name, model) if collection.options[:if].call(resource)
         end
       end
 
       private
 
       def find_resource_for_update(collection, model)
-        raise ArgumentError, "Could not find inverse_of for #{collection[:name]}" unless collection[:inverse_association]
+        collection.reflection ||= collection.klass.reflect_on_association(collection.name)
+
+        collection.foreign_key ||= collection.reflection.foreign_key
+
+        # lazy load and store through and inverse associations
+        if collection.reflection&.through_reflection?
+          collection.inverse_association ||= collection.reflection.through_reflection.inverse_of&.name&.to_s
+          collection.through_association = collection.reflection.through_reflection.name.to_s.singularize
+        else
+          collection.inverse_association ||= collection.reflection.inverse_of&.name&.to_s
+        end
+
+        raise ArgumentError, "Could not find inverse_of for #{collection.name}" unless collection.inverse_association
 
         resource = model
-        resource = resource.send(collection[:through_association].underscore) if collection[:through_association]
-        resource.send(collection[:inverse_association].underscore)
+        resource = resource.send(collection.through_association.underscore) if collection.through_association
+        resource.send(collection.inverse_association.underscore)
       end
     end
   end

--- a/app/models/concerns/cable_ready/updatable/collections_registry.rb
+++ b/app/models/concerns/cable_ready/updatable/collections_registry.rb
@@ -41,8 +41,8 @@ module CableReady
 
         # lazy load and store through and inverse associations
         if collection.reflection&.through_reflection?
-          collection.inverse_association ||= collection.reflection&.through_reflection.inverse_of&.name&.to_s
-          collection.through_association = collection.reflection&.through_reflection.name.to_s.singularize
+          collection.inverse_association ||= collection.reflection&.through_reflection&.inverse_of&.name&.to_s
+          collection.through_association = collection.reflection&.through_reflection&.name&.to_s&.singularize
         else
           collection.inverse_association ||= collection.reflection&.inverse_of&.name&.to_s
         end

--- a/package.json
+++ b/package.json
@@ -35,10 +35,8 @@
     "javascript/*"
   ],
   "scripts": {
-    "lint": "yarn run prettier-standard:check",
-    "format": "yarn run prettier-standard:format",
-    "prettier-standard:check": "yarn run prettier-standard --check ./javascript/**/*.js rollup.config.js",
-    "prettier-standard:format": "yarn run prettier-standard ./javascript/**/*.js rollup.config.js",
+    "lint": "yarn run format --check",
+    "format": "yarn run prettier-standard ./javascript/**/*.js rollup.config.mjs",
     "build": "yarn rollup -c",
     "watch": "yarn rollup -wc",
     "test": "web-test-runner javascript/test/**/*.test.js",

--- a/test/dummy/app/models/listing.rb
+++ b/test/dummy/app/models/listing.rb
@@ -1,0 +1,6 @@
+class Listing < ApplicationRecord
+  include CableReady::Updatable
+
+  belongs_to :user
+  has_many :actions, class_name: "Listings::Action", dependent: :destroy, foreign_key: :listing_id, enable_cable_ready_updates: true, inverse_of: :listing
+end

--- a/test/dummy/app/models/listings.rb
+++ b/test/dummy/app/models/listings.rb
@@ -1,0 +1,5 @@
+module Listings
+  def self.table_name_prefix
+    'listings_'
+  end
+end

--- a/test/dummy/app/models/listings/action.rb
+++ b/test/dummy/app/models/listings/action.rb
@@ -1,0 +1,3 @@
+class Listings::Action < ApplicationRecord
+  belongs_to :listing, class_name: "Listing"
+end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
 
   has_many :posts, enable_cable_ready_updates: true
   belongs_to :team, optional: true, touch: true
+  has_many :listings
+  has_many :actions, class_name: "Listings::Action", through: :listings, enable_cable_ready_updates: true, foreign_key: :listing_id
 end

--- a/test/dummy/db/migrate/20230301110606_create_listings.rb
+++ b/test/dummy/db/migrate/20230301110606_create_listings.rb
@@ -1,0 +1,10 @@
+class CreateListings < ActiveRecord::Migration[6.1]
+  def change
+    create_table :listings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/migrate/20230301112847_create_listings_actions.rb
+++ b/test/dummy/db/migrate/20230301112847_create_listings_actions.rb
@@ -1,0 +1,10 @@
+class CreateListingsActions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :listings_actions do |t|
+      t.references :listing, null: false, foreign_key: true
+      t.string :kind
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_18_072701) do
+ActiveRecord::Schema.define(version: 2023_03_01_112847) do
 
   create_table "accounts", force: :cascade do |t|
     t.string "account_number"
@@ -64,6 +62,22 @@ ActiveRecord::Schema.define(version: 2022_05_18_072701) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "listings", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_listings_on_user_id"
+  end
+
+  create_table "listings_actions", force: :cascade do |t|
+    t.integer "listing_id", null: false
+    t.string "kind"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["listing_id"], name: "index_listings_actions_on_listing_id"
+  end
+
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.integer "user_id", null: false
@@ -74,6 +88,12 @@ ActiveRecord::Schema.define(version: 2022_05_18_072701) do
 
   create_table "sections", force: :cascade do |t|
     t.string "title"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "sites", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -107,5 +127,7 @@ ActiveRecord::Schema.define(version: 2022_05_18_072701) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blocks", "sections"
+  add_foreign_key "listings", "users"
+  add_foreign_key "listings_actions", "listings"
   add_foreign_key "posts", "users"
 end

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -229,4 +229,30 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
     end
   end
   # standard:enable Lint/ConstantDefinitionInBlock
+
+  test "resolves inverse_of correctly" do
+    mock_server = mock("server")
+    mock_server.expects(:broadcast).with(User, {}).once
+    mock_server.expects(:broadcast).with("gid://dummy/User/1:actions", {changed: ["id", "listing_id", "kind", "created_at", "updated_at"]}).once
+    mock_server.expects(:broadcast).with("gid://dummy/Listing/1:actions", {changed: ["id", "listing_id", "kind", "created_at", "updated_at"]}).once
+
+    ActionCable.stubs(:server).returns(mock_server)
+    user = User.create(name: "John Doe")
+    listing = user.listings.create(name: "test listing")
+
+    listing.actions.create(kind: "publish")
+  end
+
+  test "resolves inverse_of for has_many :through correctly" do
+    mock_server = mock("server")
+    mock_server.expects(:broadcast).with(User, {}).once
+    mock_server.expects(:broadcast).with("gid://dummy/User/1:actions", {changed: ["id", "listing_id", "kind", "created_at", "updated_at"]}).once
+    mock_server.expects(:broadcast).with("gid://dummy/Listing/1:actions", {changed: ["id", "listing_id", "kind", "created_at", "updated_at"]}).once
+
+    ActionCable.stubs(:server).returns(mock_server)
+    user = User.create(name: "John Doe")
+    listing = user.listings.create(name: "test listing")
+
+    listing.actions.create(kind: "publish")
+  end
 end


### PR DESCRIPTION
# Bug Fix

## Description

This is more or less a reimplementation of a patch that @andrewculver made to fix `inverse_of` resolution. I just took it a bit further and lazy loaded/stored reflection properties in the finder, because it's useless to do the work twice, and declutters the main module a bit

https://github.com/stimulusreflex/cable_ready/compare/master...andrewculver:cable_ready:master?diff=split

(maybe) Fixes #258 
awaiting confirmation from the BulletTrain team cc @andrewculver

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
