### PR TITLE
Set default debounce time in CableReady::Config

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -57,7 +57,7 @@ module CableReady
           options = {
             on: [:create, :update, :destroy],
             if: -> { true },
-            debounce: 0.seconds
+            debounce: CableReady.config.updatable_debounce_time
           }.merge(options)
 
           enabled_operations = Array(options[:on])
@@ -228,7 +228,7 @@ module CableReady
       end
 
       def debounce_time
-        @debounce_time ||= 0.seconds
+        @debounce_time ||= CableReady.config.updatable_debounce_time
       end
 
       def skip_updates_classes

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -212,13 +212,13 @@ module CableReady
         return if skip_updates_classes.any? { |klass| klass >= self }
         raise("ActionCable must be enabled to use Updatable") unless defined?(ActionCable)
 
-        if debounce_time > 0.seconds
+        if debounce_time > 0
           key = compound([model_class, *options])
           old_wait_until = CableReady::Updatable.debounce_adapter[key]
           now = Time.now.to_f
 
           if old_wait_until.nil? || old_wait_until < now
-            new_wait_until = now + debounce_time.to_f
+            new_wait_until = now + debounce_time
             CableReady::Updatable.debounce_adapter[key] = new_wait_until
             ActionCable.server.broadcast(model_class, options)
           end
@@ -229,6 +229,8 @@ module CableReady
 
       def debounce_time
         @debounce_time ||= CableReady.config.updatable_debounce_time
+
+        @debounce_time.to_f
       end
 
       def skip_updates_classes

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -28,7 +28,7 @@ module CableReady
       @on_failed_sanity_checks = :exit
       @broadcast_job_queue = :default
       @precompile_assets = true
-      @updatable_debounce_time = 0.seconds
+      @updatable_debounce_time = 0.1.seconds
     end
 
     def observers

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -11,7 +11,7 @@ module CableReady
     include Observable
     include Singleton
 
-    attr_accessor :on_failed_sanity_checks, :broadcast_job_queue, :precompile_assets
+    attr_accessor :on_failed_sanity_checks, :broadcast_job_queue, :precompile_assets, :updatable_debounce_time
     attr_writer :verifier_key
 
     def on_new_version_available
@@ -28,6 +28,7 @@ module CableReady
       @on_failed_sanity_checks = :exit
       @broadcast_job_queue = :default
       @precompile_assets = true
+      @updatable_debounce_time = 0.seconds
     end
 
     def observers

--- a/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
+++ b/lib/generators/cable_ready/templates/config/initializers/cable_ready.rb
@@ -19,4 +19,9 @@ CableReady.configure do |config|
   # Change the default Active Job queue used for broadcast_later and broadcast_later_to
   #
   # config.broadcast_job_queue = :default
+
+  # Specify a default debounce time for CableReady::Updatable callbacks
+  # Doing so is a best practice to avoid heavy ActionCable traffic
+  #
+  # config.updatable_debounce_time = 0.1.seconds
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,5 @@ require "pry"
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+
+CableReady.config.updatable_debounce_time = 0.seconds


### PR DESCRIPTION
# Enhancement

## Description

Allows to set the default `updatable_debounce_time` in the CableReady config. This allows every application to set it to a desired value

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
