### PR TITLE
Updatable debounce associations

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -62,11 +62,9 @@ module CableReady
 
           enabled_operations = Array(options[:on])
 
-          @debounce_time = options[:debounce]
-
-          after_commit(ModelUpdatableCallbacks.new(:create, enabled_operations), {on: :create, if: options[:if]})
-          after_commit(ModelUpdatableCallbacks.new(:update, enabled_operations), {on: :update, if: options[:if]})
-          after_commit(ModelUpdatableCallbacks.new(:destroy, enabled_operations), {on: :destroy, if: options[:if]})
+          after_commit(ModelUpdatableCallbacks.new(:create, enabled_operations, debounce: options[:debounce]), {on: :create, if: options[:if]})
+          after_commit(ModelUpdatableCallbacks.new(:update, enabled_operations, debounce: options[:debounce]), {on: :update, if: options[:if]})
+          after_commit(ModelUpdatableCallbacks.new(:destroy, enabled_operations, debounce: options[:debounce]), {on: :destroy, if: options[:if]})
         end
 
         def self.skip_cable_ready_updates
@@ -92,10 +90,11 @@ module CableReady
         end
 
         descendants = options.delete(:descendants)
+        debounce_time = options.delete(:debounce)
 
         broadcast = option.present?
         result = super
-        enrich_association_with_updates(name, option, descendants) if broadcast
+        enrich_association_with_updates(name, option, descendants, debounce: debounce_time) if broadcast
         result
       end
 
@@ -108,10 +107,11 @@ module CableReady
         end
 
         descendants = options.delete(:descendants)
+        debounce_time = options.delete(:debounce)
 
         broadcast = option.present?
         result = super
-        enrich_association_with_updates(name, option, descendants) if broadcast
+        enrich_association_with_updates(name, option, descendants, debounce: debounce_time) if broadcast
         result
       end
 
@@ -125,9 +125,11 @@ module CableReady
           options.delete(:enable_cable_ready_updates)
         end
 
+        debounce_time = options.delete(:debounce)
+
         broadcast = option.present?
         result = super
-        enrich_attachments_with_updates(name, option) if broadcast
+        enrich_attachments_with_updates(name, option, debounce: debounce_time) if broadcast
         result
       end
 
@@ -135,12 +137,15 @@ module CableReady
         @cable_ready_collections ||= CollectionsRegistry.new
       end
 
-      def cable_ready_update_collection(resource, name, model)
+      def cable_ready_update_collection(resource, name, model, debounce: CableReady.config.updatable_debounce_time)
         identifier = resource.to_global_id.to_s + ":" + name.to_s
-        broadcast_updates(identifier, model.respond_to?(:previous_changes) ? {changed: model.previous_changes.keys} : {})
+        changeset = model.respond_to?(:previous_changes) ? {changed: model.previous_changes.keys} : {}
+        options = changeset.merge({debounce: debounce})
+
+        broadcast_updates(identifier, options)
       end
 
-      def enrich_association_with_updates(name, option, descendants = nil)
+      def enrich_association_with_updates(name, option, descendants = nil, debounce: CableReady.config.updatable_debounce_time)
         reflection = reflect_on_association(name)
 
         options = build_options(option)
@@ -151,12 +156,13 @@ module CableReady
             klass: self,
             name: name,
             options: options,
-            reflection: reflection
+            reflection: reflection,
+            debounce_time: debounce
           ))
         end
       end
 
-      def enrich_attachments_with_updates(name, option)
+      def enrich_attachments_with_updates(name, option, debounce: 0.seconds)
         options = build_options(option)
 
         ActiveStorage::Attachment.send(:include, CableReady::Updatable) unless ActiveStorage::Attachment.respond_to?(:cable_ready_collections)
@@ -167,7 +173,8 @@ module CableReady
           name: name,
           inverse_association: "record",
           through_association: nil,
-          options: options
+          options: options,
+          debounce_time: debounce
         ))
       end
 
@@ -202,25 +209,22 @@ module CableReady
         return if skip_updates_classes.any? { |klass| klass >= self }
         raise("ActionCable must be enabled to use Updatable") unless defined?(ActionCable)
 
-        if debounce_time > 0
+        debounce_time = options.delete(:debounce)
+        debounce_time ||= CableReady.config.updatable_debounce_time
+
+        if debounce_time.to_f > 0
           key = compound([model_class, *options])
           old_wait_until = CableReady::Updatable.debounce_adapter[key]
           now = Time.now.to_f
 
           if old_wait_until.nil? || old_wait_until < now
-            new_wait_until = now + debounce_time
+            new_wait_until = now + debounce_time.to_f
             CableReady::Updatable.debounce_adapter[key] = new_wait_until
             ActionCable.server.broadcast(model_class, options)
           end
         else
           ActionCable.server.broadcast(model_class, options)
         end
-      end
-
-      def debounce_time
-        @debounce_time ||= CableReady.config.updatable_debounce_time
-
-        @debounce_time.to_f
       end
 
       def skip_updates_classes

--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -162,7 +162,7 @@ module CableReady
         end
       end
 
-      def enrich_attachments_with_updates(name, option, debounce: 0.seconds)
+      def enrich_attachments_with_updates(name, option, debounce: CableReady.config.updatable_debounce_time)
         options = build_options(option)
 
         ActiveStorage::Attachment.send(:include, CableReady::Updatable) unless ActiveStorage::Attachment.respond_to?(:cable_ready_collections)

--- a/app/models/concerns/cable_ready/updatable/collections_registry.rb
+++ b/app/models/concerns/cable_ready/updatable/collections_registry.rb
@@ -10,6 +10,7 @@ module CableReady
       :foreign_key,
       :inverse_association,
       :through_association,
+      :debounce_time,
       keyword_init: true
     )
 
@@ -28,7 +29,7 @@ module CableReady
           resource = find_resource_for_update(collection, model)
           next if resource.nil?
 
-          collection.klass.cable_ready_update_collection(resource, collection.name, model) if collection.options[:if].call(resource)
+          collection.klass.cable_ready_update_collection(resource, collection.name, model, debounce: collection.debounce_time) if collection.options[:if].call(resource)
         end
       end
 

--- a/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
+++ b/app/models/concerns/cable_ready/updatable/model_updatable_callbacks.rb
@@ -3,9 +3,10 @@
 module CableReady
   module Updatable
     class ModelUpdatableCallbacks
-      def initialize(operation, enabled_operations = %i[create update destroy])
+      def initialize(operation, enabled_operations = %i[create update destroy], debounce: CableReady.config.updatable_debounce_time)
         @operation = operation
         @enabled_operations = enabled_operations
+        @debounce = debounce
       end
 
       def after_commit(model)
@@ -17,14 +18,15 @@ module CableReady
       private
 
       def broadcast_create(model)
-        model.class.send(:broadcast_updates, model.class, {})
+        model.class.send(:broadcast_updates, model.class, {debounce: @debounce})
       end
       alias_method :broadcast_destroy, :broadcast_create
 
       def broadcast_update(model)
         changeset = model.respond_to?(:previous_changes) ? {changed: model.previous_changes.keys} : {}
-        model.class.send(:broadcast_updates, model.class, changeset)
-        model.class.send(:broadcast_updates, model.to_global_id, changeset)
+        options = changeset.merge({debounce: @debounce})
+        model.class.send(:broadcast_updates, model.class, options.dup)
+        model.class.send(:broadcast_updates, model.to_global_id, options)
       end
     end
   end

--- a/test/dummy/app/models/rule.rb
+++ b/test/dummy/app/models/rule.rb
@@ -1,0 +1,5 @@
+class Rule < ApplicationRecord
+  include CableReady::Updatable
+
+  belongs_to :site
+end

--- a/test/dummy/app/models/site.rb
+++ b/test/dummy/app/models/site.rb
@@ -2,4 +2,6 @@ class Site < ApplicationRecord
   include CableReady::Updatable
 
   enable_cable_ready_updates debounce: 3.seconds
+
+  has_many :rules, enable_cable_ready_updates: true, debounce: 5.seconds
 end

--- a/test/dummy/db/migrate/20230303125513_create_rules.rb
+++ b/test/dummy/db/migrate/20230303125513_create_rules.rb
@@ -1,0 +1,10 @@
+class CreateRules < ActiveRecord::Migration[6.1]
+  def change
+    create_table :rules do |t|
+      t.string :name
+      t.references :site
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_01_112847) do
+ActiveRecord::Schema.define(version: 2023_03_03_125513) do
+
   create_table "accounts", force: :cascade do |t|
     t.string "account_number"
     t.integer "supplier_id", null: false
@@ -83,6 +84,14 @@ ActiveRecord::Schema.define(version: 2023_03_01_112847) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "rules", force: :cascade do |t|
+    t.string "name"
+    t.integer "site_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["site_id"], name: "index_rules_on_site_id"
   end
 
   create_table "sections", force: :cascade do |t|

--- a/test/lib/cable_ready/updatable_test.rb
+++ b/test/lib/cable_ready/updatable_test.rb
@@ -272,4 +272,19 @@ class CableReady::UpdatableTest < ActiveSupport::TestCase
     travel(3.seconds)
     site.update(name: "Landing Page 3")
   end
+
+  test "only sends out a ping once per debounce period when an item is added to a collection" do
+    site = Site.create(name: "Front Page")
+
+    mock_server = mock("server")
+    mock_server.expects(:broadcast).with("gid://dummy/Site/1:rules", {changed: ["id", "name", "site_id", "created_at", "updated_at"]}).once
+
+    ActionCable.stubs(:server).returns(mock_server)
+
+    site.rules.create(name: "public")
+    travel(1.second)
+    site.rules.create(name: "private")
+    travel(3.seconds)
+    site.rules.create(name: "admin")
+  end
 end


### PR DESCRIPTION
# Enhancement

## Description

This is an extension of the debounce mechanism to associations. Note that I switched to passing the debounce time around via method arguments rather than instance variables, because it was cleaner to do so from both the model class as well the association extension side.

There may be some opportunities to declutter this a bit, though at the moment they're not obvious to me.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
