### PR TITLE
Make memory debounce adapter use MemoryCacheStore

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -6,31 +6,7 @@ module CableReady
   module Updatable
     extend ::ActiveSupport::Concern
 
-    class MemoryDebounceAdapter
-      include Singleton
-      include MonitorMixin
-
-      delegate_missing_to :@dict
-
-      def initialize
-        super
-        @dict = {}
-      end
-
-      def []=(key, value)
-        synchronize do
-          @dict[key] = value
-        end
-      end
-
-      def [](key)
-        synchronize do
-          @dict[key]
-        end
-      end
-    end
-
-    mattr_accessor :debounce_adapter, default: MemoryDebounceAdapter.instance
+    mattr_accessor :debounce_adapter, default: MemoryCacheDebounceAdapter.instance
 
     included do |base|
       if defined?(ActiveRecord) && base < ActiveRecord::Base

--- a/lib/cable_ready.rb
+++ b/lib/cable_ready.rb
@@ -17,6 +17,8 @@ require "cable_ready/version"
 require "cable_ready_helper"
 
 module CableReady
+  autoload :MemoryCacheDebounceAdapter, "cable_ready/updatable/memory_cache_debounce_adapter"
+
   class << self
     def config
       CableReady::Config.instance

--- a/lib/cable_ready/updatable/memory_cache_debounce_adapter.rb
+++ b/lib/cable_ready/updatable/memory_cache_debounce_adapter.rb
@@ -1,0 +1,22 @@
+module CableReady
+  module Updatable
+    class MemoryCacheDebounceAdapter
+      include Singleton
+
+      delegate_missing_to :@store
+
+      def initialize
+        super
+        @store = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes)
+      end
+
+      def []=(key, value)
+        @store.write(key, value)
+      end
+
+      def [](key)
+        @store.read(key)
+      end
+    end
+  end
+end

--- a/lib/cable_ready/updatable/memory_cache_debounce_adapter.rb
+++ b/lib/cable_ready/updatable/memory_cache_debounce_adapter.rb
@@ -7,7 +7,7 @@ module CableReady
 
       def initialize
         super
-        @store = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes)
+        @store = ActiveSupport::Cache::MemoryStore.new(expires_in: 5.minutes, size: 8.megabytes)
       end
 
       def []=(key, value)


### PR DESCRIPTION
# Enhancement

## Description

Makes the memory debounce adapter use `ActiveSupport::MemoryCacheStore` inherently, with a default expiration time of 5 minutes.

Note that I also moved it to a new adapters directory in anticipation of other adapters.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
