### PR TITLE
Remove unused `url_helpers` include from installer

### DIFF
--- a/lib/tasks/cable_ready/cable_ready.rake
+++ b/lib/tasks/cable_ready/cable_ready.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-include Rails.application.routes.url_helpers
-
 CR_STEPS = {
   "action_cable" => "Action Cable",
   "webpacker" => "Install CableReady using Webpacker",


### PR DESCRIPTION
# Type of PR 

Bug fix

## Description

The CableReady installer still had an include for `include Rails.application.routes.url_helpers`, which is not used anymore. This pull request removes that include call.

Fixes #265 

## Why should this be added

Since we don't need to have all route url helpers in the global namespace we can remove the call. Additionally, it also causes some issue in certain cases, see #265.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
