### PR TITLE
Fix ReferenceError

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -195,7 +195,7 @@ class Block {
           const frameContent = frameTemplate.content.querySelector(selector)
           const content = frameContent ? frameContent.innerHTML.trim() : ''
 
-          docFragment.querySelector(selector).innerHTML = content
+          documentFragment.querySelector(selector).innerHTML = content
 
           resolve()
         })


### PR DESCRIPTION
# Bug fix

## Description
I think we have a misnamed variable hidden lurking about in `updates_for_element.js`. Specifically: a `docFragment` that should read `documentFragment` (leading to `ReferenceError: docFragment is not defined`).

This PR updates the name accordingly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
