### PR TITLE
Remove minified dist files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ yarn add cable_ready
 
 # ...
 
-pin 'cable_ready', to: 'cable_ready.min.js', preload: true
+pin 'cable_ready', to: 'cable_ready.js', preload: true
 ```
 
 #### Rails Asset pipeline (Sprockets):
@@ -88,7 +88,7 @@ pin 'cable_ready', to: 'cable_ready.min.js', preload: true
 ```html+erb
 <!-- app/views/layouts/application.html.erb -->
 
-<%= javascript_include_tag "cable_ready.umd.min.js", "data-turbo-track": "reload" %>
+<%= javascript_include_tag "cable_ready.umd.js", "data-turbo-track": "reload" %>
 ```
 
 Checkout the [documentation](https://cableready.stimulusreflex.com) to continue!

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -12,11 +12,7 @@ module CableReady
     # end
     PRECOMPILE_ASSETS = %w[
       cable_ready.js
-      cable_ready.min.js
-      cable_ready.min.js.map
       cable_ready.umd.js
-      cable_ready.umd.min.js
-      cable_ready.umd.min.js.map
     ]
 
     initializer "cable_ready.assets" do |app|

--- a/lib/cable_ready/importmap.rb
+++ b/lib/cable_ready/importmap.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 pin "morphdom", to: "https://ga.jspm.io/npm:morphdom@2.6.1/dist/morphdom.js", preload: true
-pin "cable_ready", to: "cable_ready.min.js", preload: true
+pin "cable_ready", to: "cable_ready.js", preload: true

--- a/lib/install/importmap.rb
+++ b/lib/install/importmap.rb
@@ -42,7 +42,7 @@ backup(importmap_path) do
 
   if !importmap.include?("pin \"cable_ready\"")
     append_file(importmap_path, <<~RUBY, verbose: false)
-      pin "cable_ready", to: "cable_ready.min.js", preload: true
+      pin "cable_ready", to: "cable_ready.js", preload: true
     RUBY
     say "✅ pin CableReady"
   end

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -14,13 +14,6 @@ const pretty = () => {
   })
 }
 
-const minify = () => {
-  return terser({
-    mangle: true,
-    compress: true
-  })
-}
-
 const esConfig = {
   format: 'es',
   inlineDynamicImports: true
@@ -44,22 +37,10 @@ const output = distFolders
       plugins: [pretty()]
     },
     {
-      ...esConfig,
-      file: `${distFolder}/${baseName}.min.js`,
-      sourcemap: true,
-      plugins: [minify()]
-    },
-    {
       ...umdConfig,
       file: `${distFolder}/${baseName}.umd.js`,
       plugins: [pretty()]
     },
-    {
-      ...umdConfig,
-      file: `${distFolder}/${baseName}.umd.min.js`,
-      sourcemap: true,
-      plugins: [minify()]
-    }
   ])
   .flat()
 


### PR DESCRIPTION
# Type of PR

Simplification

## Description

In a world where JavaScript bundling in the Ruby on Rails landscape is being pushed more and more towards the developer itself it should also be up to them how, why and if they bundle/minify/compress their (JavaScript) assets. So it's becoming more and more irrelevant for NPM packages and gems to ship both regular and minified+map dist files if they are never/rarely needed.

## Why should this be added

This brings a few benefits:
- Reduces the npm package size and shipped number of files inside the package
- Reduces the gem size and shipped number of files inside the gem
- Reduces the amount of assets to be precompiled in the Rails assets pipeline, if you haven't actively excluded them.
- Reduces the build time for building the library when running `yarn build`
- Make it easier for us to maintain because there are less files which are needed to get built
- Makes it easier to debug, because the error messags refer to line-numers, rather then line number 1 in a minified file

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
