### PR TITLE
Include `*.js.tt` files in bundled gem

### DIFF
--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.summary = "Out-of-Band Server Triggered DOM Operations"
 
   gem.files = Dir[
-    "lib/**/*.{rb,rake}",
+    "lib/**/*.{rb,rake,tt}",
     "app/**/*.rb",
     "app/assets/javascripts/*",
     "bin/*",


### PR DESCRIPTION
# Type of PR

Bug fix

## Description

All template files for the installer (`*.js.tt`) were missing in the bundled gem. This pull requests adds the `*.tt` ending to the `files` config inside the `gemspec`.

## Why should this be added

So the installer works properly again. The installer was failing with:
```ruby
--- [esbuild] ----
rails aborted!
Thor::Error: Could not find "/3.2.0/gems/cable_ready-5.0.0.rc2/lib/generators/cable_ready/templates/esbuild.config.mjs.tt" in any of your source paths. Your current source paths are:
/3.2.0/lib/ruby/gems/3.2.0/gems/railties-7.0.4.3/lib/rails/generators/rails/app/templates

Tasks: TOP => app:template
(See full trace by running task with --trace)

--- [config] ----
rails aborted!
Thor::Error: Could not find "/3.2.0/gems/cable_ready-5.0.0.rc2/lib/generators/cable_ready/templates/app/javascript/config/index.js.tt" in any of your source paths. Your current source paths are:
/3.2.0/gems/railties-7.0.4.3/lib/rails/generators/rails/app/templates
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
