### PR TITLE
Add trigger and target element logs for devtools

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -61,11 +61,16 @@ export default class UpdatesForElement extends SubscribingElement {
       element => new Block(element)
     ).filter(block => block.shouldUpdate(data))
 
-    this.triggerElementLog.push(Log.request(data, blocks))
+    this.triggerElementLog.push(
+      `${new Date().toLocaleString()}: ${Log.request(data, blocks)}`
+    )
 
     if (blocks.length === 0) {
       this.triggerElementLog.push(
-        Log.cancel(this.lastUpdateTimestamp, 'All elements filtered out')
+        `${new Date().toLocaleString()}: ${Log.cancel(
+          this.lastUpdateTimestamp,
+          'All elements filtered out'
+        )}`
       )
 
       return
@@ -74,7 +79,10 @@ export default class UpdatesForElement extends SubscribingElement {
     // first <cable-ready-updates-for> element in the DOM *at any given moment* updates all of the others
     if (blocks[0].element !== this) {
       this.triggerElementLog.push(
-        Log.cancel(this.lastUpdateTimestamp, 'Update already requested')
+        `${new Date().toLocaleString()}: ${Log.cancel(
+          this.lastUpdateTimestamp,
+          'Update already requested'
+        )}`
       )
 
       return
@@ -100,7 +108,11 @@ export default class UpdatesForElement extends SubscribingElement {
     )
 
     this.triggerElementLog.push(
-      Log.response(this.lastUpdateTimestamp, this, uniqueUrls)
+      `${new Date().toLocaleString()}: ${Log.response(
+        this.lastUpdateTimestamp,
+        this,
+        uniqueUrls
+      )}`
     )
 
     // track current block index for each URL; referred to as fragments
@@ -162,7 +174,10 @@ class Block {
 
     dispatch(this.element, 'cable-ready:before-update', operation)
     this.element.targetElementLog.push(
-      Log.morphStart(startTimestamp, this.element)
+      `${new Date().toLocaleString()}: ${Log.morphStart(
+        startTimestamp,
+        this.element
+      )}`
     )
 
     morphdom(this.element, fragments[blockIndex], {
@@ -176,7 +191,10 @@ class Block {
     })
 
     this.element.targetElementLog.push(
-      Log.morphEnd(startTimestamp, this.element)
+      `${new Date().toLocaleString()}: ${Log.morphEnd(
+        startTimestamp,
+        this.element
+      )}`
     )
   }
 

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -7,6 +7,7 @@ import { debounce, assignFocus, dispatch, graciouslyFetch } from '../utils'
 import ActiveElement from '../active_element'
 import CableConsumer from '../cable_consumer'
 import Log from '../updatable/log'
+import { BoundedQueue } from '../utils'
 
 const template = `
 <style>
@@ -33,8 +34,8 @@ export default class UpdatesForElement extends SubscribingElement {
     const shadowRoot = this.attachShadow({ mode: 'open' })
     shadowRoot.innerHTML = template
 
-    this.triggerElementLog = []
-    this.targetElementLog = []
+    this.triggerElementLog = new BoundedQueue(10)
+    this.targetElementLog = new BoundedQueue(10)
   }
 
   async connectedCallback () {

--- a/javascript/updatable/log.js
+++ b/javascript/updatable/log.js
@@ -3,51 +3,65 @@ import Debug from '../debug'
 const request = (data, blocks) => {
   if (Debug.disabled) return
 
-  console.log(
-    `\u2191 Updatable request affecting ${blocks.length} element(s): `,
-    {
-      elements: blocks.map(b => b.element),
-      identifiers: blocks.map(b => b.element.getAttribute('identifier')),
-      data
-    }
-  )
+  const message = `\u2191 Updatable request affecting ${blocks.length} element(s): `
+
+  console.log(message, {
+    elements: blocks.map(b => b.element),
+    identifiers: blocks.map(b => b.element.getAttribute('identifier')),
+    data
+  })
+
+  return message
 }
 
 const cancel = (timestamp, reason) => {
   if (Debug.disabled) return
 
   const duration = new Date() - timestamp
-  console.log(
-    `\u274C Updatable request canceled after ${duration}ms: ${reason}`
-  )
+  const message = `\u274C Updatable request canceled after ${duration}ms: ${reason}`
+  console.log(message)
+
+  return message
 }
 
 const response = (timestamp, element, urls) => {
   if (Debug.disabled) return
 
   const duration = new Date() - timestamp
-  console.log(`\u2193 Updatable response: All URLs fetched in ${duration}ms`, {
+  const message = `\u2193 Updatable response: All URLs fetched in ${duration}ms`
+
+  console.log(message, {
     element,
     urls
   })
+
+  return message
 }
 
 const morphStart = (timestamp, element) => {
   if (Debug.disabled) return
 
   const duration = new Date() - timestamp
-  console.log(`\u21BB Updatable morph: starting after ${duration}ms`, {
+  const message = `\u21BB Updatable morph: starting after ${duration}ms`
+
+  console.log(message, {
     element
   })
+
+  return message
 }
 
 const morphEnd = (timestamp, element) => {
   if (Debug.disabled) return
 
   const duration = new Date() - timestamp
-  console.log(`\u21BA Updatable morph: completed after ${duration}ms`, {
+  const message = `\u21BA Updatable morph: completed after ${duration}ms`
+
+  console.log(message, {
     element
   })
+
+  return message
 }
 
 export default { request, cancel, response, morphStart, morphEnd }

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -205,6 +205,29 @@ async function graciouslyFetch (url, additionalHeaders) {
   }
 }
 
+class BoundedQueue {
+  constructor (maxSize) {
+    this.maxSize = maxSize
+    this.queue = []
+  }
+
+  push (item) {
+    if (this.isFull()) {
+      // Remove the oldest item to make space for the new one
+      this.shift()
+    }
+    this.queue.push(item)
+  }
+
+  shift () {
+    return this.queue.shift()
+  }
+
+  isFull () {
+    return this.queue.length === this.maxSize
+  }
+}
+
 export {
   isTextInput,
   assignFocus,
@@ -225,5 +248,6 @@ export {
   safeArray,
   safeObject,
   safeStringOrArray,
-  fragmentToString
+  fragmentToString,
+  BoundedQueue
 }


### PR DESCRIPTION
# Enhancement

## Description

Furnishes cable-ready-updates-for-element with instance variables for element logs, so they can displayed in the devtools like this:

![CleanShot 2023-05-08 at 12 22 44@2x](https://user-images.githubusercontent.com/4352208/236800677-53feffad-3dc5-4159-8483-4dadf86236d4.png)
