### PR TITLE
Fix lingering class-loading issues with CableReady::Updatable concern

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
+require "cable_ready/updatable/memory_cache_debounce_adapter"
 
 module CableReady
   module Updatable
     extend ::ActiveSupport::Concern
 
-    mattr_accessor :debounce_adapter, default: ::CableReady::Updatable::MemoryCacheDebounceAdapter.instance
+    mattr_accessor :debounce_adapter, default: MemoryCacheDebounceAdapter.instance
 
     included do |base|
       if defined?(ActiveRecord) && base < ActiveRecord::Base


### PR DESCRIPTION
# Bugfix

## Description

There's still some weirdness with the way the `MemoryCacheDebounceAdapter` is being loaded in `CableReady::Updatable` concern. Notes on the previous fix here: https://github.com/stimulusreflex/cable_ready/pull/274#issuecomment-1565767491

It seems to be resolved now, I'm not seeing the intermittent errors after this tweak :+1:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
