### PR TITLE
Set xpath flag if/when overwriting selector with previous_selector

### DIFF
--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -3,7 +3,7 @@
 module CableReady
   class OperationBuilder
     include Identifiable
-    attr_reader :identifier, :previous_selector
+    attr_reader :identifier, :previous_selector, :previous_xpath
 
     def self.finalizer_for(identifier)
       proc {
@@ -45,10 +45,11 @@ module CableReady
         options["selector"] = selector if selector && options.exclude?("selector")
         if previous_selector && options.exclude?("selector")
           options["selector"] = previous_selector
-          options["xpath"] = true if options["selector"].to_s.starts_with? "/"
+          options["xpath"] = previous_xpath if previous_xpath
         end
         if options.include?("selector")
           @previous_selector = options["selector"]
+          @previous_xpath = options["xpath"]
           options["selector"] = identifiable?(previous_selector) ? dom_id(previous_selector) : previous_selector
         end
         options["operation"] = name.to_s.camelize(:lower)

--- a/lib/cable_ready/operation_builder.rb
+++ b/lib/cable_ready/operation_builder.rb
@@ -43,7 +43,10 @@ module CableReady
           options.each { |key, value| options[key] = value.send("to_#{key}".to_sym) if value.respond_to?("to_#{key}".to_sym) }
         end
         options["selector"] = selector if selector && options.exclude?("selector")
-        options["selector"] = previous_selector if previous_selector && options.exclude?("selector")
+        if previous_selector && options.exclude?("selector")
+          options["selector"] = previous_selector
+          options["xpath"] = true if options["selector"].to_s.starts_with? "/"
+        end
         if options.include?("selector")
           @previous_selector = options["selector"]
           options["selector"] = identifiable?(previous_selector) ? dom_id(previous_selector) : previous_selector

--- a/test/lib/cable_ready/operation_builder_test.rb
+++ b/test/lib/cable_ready/operation_builder_test.rb
@@ -144,6 +144,19 @@ class CableReady::OperationBuilderTest < ActiveSupport::TestCase
     assert_equal(operations, @operation_builder.operations_payload)
   end
 
+  test "should set xpath correctly if re-using previous xpath selector in next operation" do
+    @operation_builder
+      .add_css_class(name: "test", selector: "/html/div[0]", xpath: true)
+      .inner_html(html: "<span>Narrow is the XPATH</span>")
+
+    operations = [
+      {"operation" => "addCssClass", "name" => "test", "selector" => "/html/div[0]", "xpath" => true},
+      {"operation" => "innerHtml", "html" => "<span>Narrow is the XPATH</span>", "selector" => "/html/div[0]", "xpath" => true}
+    ]
+
+    assert_equal(operations, @operation_builder.operations_payload)
+  end
+
   test "should clear previous_selector after calling reset!" do
     @operation_builder.add_operation_method("inner_html")
     @operation_builder.inner_html(selector: "#smelly", html: "<span>I rock</span>")


### PR DESCRIPTION
# Bug fix

## Description

When chaining operations that use a `selector` argument, subsequent operations can optionally omit the `selector` argument and the `selector` from the previous operation gets applied applied automatically (at line 46 of `CableReady::OperationBuilder` [here](https://github.com/stimulusreflex/cable_ready/blob/main/lib/cable_ready/operation_builder.rb#L46).

There's a weird edge case here that can cause the subsequent operation to fail if the first operation was using `xpath`, because the `selector` argument gets set but the `xpath` argument does not get set and defaults to `false`, eg:
```ruby
cable_ready
  .add_css_class(name: "example", selector: "/html/body/div[1]", xpath: true) # succeeds
  .inner_html(html: "fail") # fails
```
The first operation is applied correctly but the `inner_html` operation fails to find it's element, as it has `selector: "/html/body/div[1]", xpath: false`, resulting in: 

```
CableReady innerHtml operation failed due to missing DOM element for selector: '/html/body/div[1]`
```
The DOM element isn't missing, it's just not being looked for with `xpath`.

## Why should this be added

Fixes an obscure edge case when chaining operations using xpath selectors and omitting the selector in subsequent operations.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
