### PR TITLE
Debounce adapter config option

### DIFF
--- a/app/models/concerns/cable_ready/updatable.rb
+++ b/app/models/concerns/cable_ready/updatable.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require "active_support/concern"
+require "cable_ready/config"
 
 module CableReady
   module Updatable
     extend ::ActiveSupport::Concern
-
-    mattr_accessor :debounce_adapter, default: ::CableReady::Updatable::MemoryCacheDebounceAdapter.instance
 
     included do |base|
       if defined?(ActiveRecord) && base < ActiveRecord::Base
@@ -190,12 +189,12 @@ module CableReady
 
         if debounce_time.to_f > 0
           key = compound([model_class, *options])
-          old_wait_until = CableReady::Updatable.debounce_adapter[key]
+          old_wait_until = CableReady.config.updatable_debounce_adapter[key]
           now = Time.now.to_f
 
           if old_wait_until.nil? || old_wait_until < now
             new_wait_until = now + debounce_time.to_f
-            CableReady::Updatable.debounce_adapter[key] = new_wait_until
+            CableReady.config.updatable_debounce_adapter[key] = new_wait_until
             ActionCable.server.broadcast(model_class, options)
           end
         else

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -11,7 +11,7 @@ module CableReady
     include Observable
     include Singleton
 
-    attr_accessor :on_failed_sanity_checks, :broadcast_job_queue, :precompile_assets, :updatable_debounce_time
+    attr_accessor :on_failed_sanity_checks, :broadcast_job_queue, :precompile_assets, :updatable_debounce_time, :updatable_debounce_adapter
     attr_writer :verifier_key
 
     def on_new_version_available

--- a/lib/cable_ready/engine.rb
+++ b/lib/cable_ready/engine.rb
@@ -55,5 +55,9 @@ module CableReady
         app.config.importmap.cache_sweepers << Engine.root.join("app/assets/javascripts")
       end
     end
+
+    config.after_initialize do
+      CableReady.config.updatable_debounce_adapter ||= CableReady::Updatable::MemoryCacheDebounceAdapter.instance
+    end
   end
 end


### PR DESCRIPTION
# Enhancement

## Description

This allows to set a different debounce adapter than the built-in one, in preparation to building one with https://github.com/hopsoft/composite_cache_store/

Initially I wanted to move the `MemoryCacheDebounceAdapter` to `lib/cable_ready/updatable/memory_cache_debounce_adapter.rb`, but that again resulted in weird Zeitwerk issues when requiring it that led nowhere. That's why I opted into defining the default adapter in a config hook.

Eventually we'll want to move the whole updatable cod from `app/` to `lib/`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
