### PR TITLE
Require needed ActiveSupport core extensions

### DIFF
--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -2,6 +2,8 @@
 
 require "thread/local"
 
+require "active_support/core_ext/enumerable"
+
 module CableReady
   # This class is a thread local singleton: CableReady::Channels.instance
   # SEE: https://github.com/socketry/thread-local/tree/master/guides/getting-started

--- a/lib/cable_ready/config.rb
+++ b/lib/cable_ready/config.rb
@@ -4,6 +4,8 @@ require "monitor"
 require "observer"
 require "singleton"
 
+require "active_support/core_ext/numeric/time"
+
 module CableReady
   # This class is a process level singleton shared by all threads: CableReady::Config.instance
   class Config


### PR DESCRIPTION
# Type of PR 

Enhancement

## Description

When using the CableReady gem (or the `cable_ready-element` gem to be specific) outside of a Rails context it was complaining about undefined methods for:

```
NoMethodError: undefined method `seconds' for 0.1:Float
    rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/cable_ready-5.0.1/lib/cable_ready/config.rb:31:in `initialize'
```
and
```
NoMethodError: undefined method `many?' for [{:message=>"Test"}]:Array
    rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/cable_ready-5.0.1/lib/cable_ready/operation_builder.rb:41:in `block in add_operation_method'
```

Requiring the right ActiveSupport core extensions resolves those errors.

## Why should this be added

This makes the gem more portable and less Rails-dependent.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
