### PR TITLE
Wrap updates-for-element in an IntersectionObserver

### DIFF
--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -27,13 +27,13 @@ module CableReady
       tag.cable_ready_stream_from(**build_options(*keys, html_options))
     end
 
-    def cable_ready_updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, observe_intersection: false, html_options: {}, &block)
+    def cable_ready_updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, observe_appearance: false, html_options: {}, &block)
       options = build_options(*keys, html_options)
       options[:url] = url if url
       options[:debounce] = debounce if debounce
       options[:only] = only if only
       options[:"ignore-inner-updates"] = "" if ignore_inner_updates
-      options[:"observe-intersection"] = "" if observe_intersection
+      options[:"observe-appearance"] = "" if observe_appearance
       tag.cable_ready_updates_for(**options) { capture(&block) }
     end
 

--- a/app/helpers/cable_ready/view_helper.rb
+++ b/app/helpers/cable_ready/view_helper.rb
@@ -27,12 +27,13 @@ module CableReady
       tag.cable_ready_stream_from(**build_options(*keys, html_options))
     end
 
-    def cable_ready_updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, html_options: {}, &block)
+    def cable_ready_updates_for(*keys, url: nil, debounce: nil, only: nil, ignore_inner_updates: false, observe_intersection: false, html_options: {}, &block)
       options = build_options(*keys, html_options)
       options[:url] = url if url
       options[:debounce] = debounce if debounce
       options[:only] = only if only
       options[:"ignore-inner-updates"] = "" if ignore_inner_updates
+      options[:"observe-intersection"] = "" if observe_intersection
       tag.cable_ready_updates_for(**options) { capture(&block) }
     end
 

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -39,12 +39,6 @@ export default class UpdatesForElement extends SubscribingElement {
 
     this.intersecting = false
     this.didTransitionToIntersecting = false
-    this.intersectionObserver = new IntersectionObserver(
-      this.intersectionCallback.bind(this),
-      {}
-    )
-
-    this.intersectionObserver.observe(this)
   }
 
   async connectedCallback () {
@@ -59,6 +53,15 @@ export default class UpdatesForElement extends SubscribingElement {
       console.error(
         'The `cable_ready_updates_for` helper cannot connect. You must initialize CableReady with an Action Cable consumer.'
       )
+    }
+
+    if (this.observeIntersection) {
+      this.intersectionObserver = new IntersectionObserver(
+        this.intersectionCallback.bind(this),
+        {}
+      )
+
+      this.intersectionObserver.observe(this)
     }
   }
 
@@ -168,6 +171,10 @@ export default class UpdatesForElement extends SubscribingElement {
       ? parseInt(this.getAttribute('debounce'))
       : 20
   }
+
+  get observeIntersection () {
+    return this.hasAttribute('observe-intersection')
+  }
 }
 
 class Block {
@@ -268,7 +275,7 @@ class Block {
     return (
       !this.ignoresInnerUpdates &&
       this.hasChangesSelectedForUpdate(data) &&
-      this.intersecting
+      (!this.observeIntersection || this.intersecting)
     )
   }
 
@@ -307,5 +314,9 @@ class Block {
 
   get intersecting () {
     return this.element.intersecting
+  }
+
+  get observeIntersection () {
+    return this.element.observeIntersection
   }
 }

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -55,7 +55,7 @@ export default class UpdatesForElement extends SubscribingElement {
       )
     }
 
-    if (this.observeIntersection) {
+    if (this.observeAppearance) {
       this.intersectionObserver = new IntersectionObserver(
         this.intersectionCallback.bind(this),
         {}
@@ -172,8 +172,8 @@ export default class UpdatesForElement extends SubscribingElement {
       : 20
   }
 
-  get observeIntersection () {
-    return this.hasAttribute('observe-intersection')
+  get observeAppearance () {
+    return this.hasAttribute('observe-appearance')
   }
 }
 
@@ -275,7 +275,7 @@ class Block {
     return (
       !this.ignoresInnerUpdates &&
       this.hasChangesSelectedForUpdate(data) &&
-      (!this.observeIntersection || this.intersecting)
+      (!this.observeAppearance || this.intersecting)
     )
   }
 
@@ -316,7 +316,7 @@ class Block {
     return this.element.intersecting
   }
 
-  get observeIntersection () {
-    return this.element.observeIntersection
+  get observeAppearance () {
+    return this.element.observeAppearance
   }
 }

--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -40,8 +40,8 @@ export default class UpdatesForElement extends SubscribingElement {
 
     this.appearanceObserver = new AppearanceObserver(this)
 
-    this.intersecting = false
-    this.didTransitionToIntersecting = false
+    this.visible = false
+    this.didTransitionToVisible = false
   }
 
   async connectedCallback () {
@@ -94,7 +94,7 @@ export default class UpdatesForElement extends SubscribingElement {
 
     // first <cable-ready-updates-for> element in the DOM *at any given moment* updates all of the others
     // if the element becomes visible though, we have to overrule and load it
-    if (blocks[0].element !== this && !this.didTransitionToIntersecting) {
+    if (blocks[0].element !== this && !this.didTransitionToVisible) {
       this.triggerElementLog.push(
         `${new Date().toLocaleString()}: ${Log.cancel(
           this.lastUpdateTimestamp,
@@ -146,16 +146,16 @@ export default class UpdatesForElement extends SubscribingElement {
   }
 
   appearedInViewport () {
-    if (!this.intersecting) {
-      // transition from non-intersecting to intersecting forces update
-      this.didTransitionToIntersecting = true
+    if (!this.visible) {
+      // transition from invisible to visible forces update
+      this.didTransitionToVisible = true
       this.update({})
     }
-    this.intersecting = true
+    this.visible = true
   }
 
   disappearedFromViewport () {
-    this.intersecting = false
+    this.visible = false
   }
 
   get query () {
@@ -220,7 +220,7 @@ class Block {
       onBeforeElUpdated: shouldMorph(operation),
       onElUpdated: _ => {
         this.element.removeAttribute('updating')
-        this.element.didTransitionToIntersecting = false
+        this.element.didTransitionToVisible = false
         dispatch(this.element, 'cable-ready:after-update', operation)
         assignFocus(operation.focusSelector)
       }
@@ -275,7 +275,7 @@ class Block {
     return (
       !this.ignoresInnerUpdates &&
       this.hasChangesSelectedForUpdate(data) &&
-      (!this.observeAppearance || this.intersecting)
+      (!this.observeAppearance || this.visible)
     )
   }
 
@@ -312,8 +312,8 @@ class Block {
     return this.element.query
   }
 
-  get intersecting () {
-    return this.element.intersecting
+  get visible () {
+    return this.element.visible
   }
 
   get observeAppearance () {

--- a/javascript/observers/appearance_observer.js
+++ b/javascript/observers/appearance_observer.js
@@ -1,0 +1,35 @@
+export class AppearanceObserver {
+  constructor (delegate, element = null) {
+    this.delegate = delegate
+    this.element = element || delegate
+    this.started = false
+
+    this.intersectionObserver = new IntersectionObserver(this.intersect)
+  }
+
+  start () {
+    if (!this.started) {
+      this.started = true
+      this.intersectionObserver.observe(this.element)
+    }
+  }
+
+  stop () {
+    if (this.started) {
+      this.started = false
+      this.intersectionObserver.unobserve(this.element)
+    }
+  }
+
+  intersect = entries => {
+    entries.forEach(entry => {
+      if (entry.target === this.element) {
+        if (entry.isIntersecting) {
+          this.delegate.appearedInViewport()
+        } else {
+          this.delegate.disappearedFromViewport()
+        }
+      }
+    })
+  }
+}

--- a/javascript/observers/appearance_observer.js
+++ b/javascript/observers/appearance_observer.js
@@ -3,6 +3,7 @@ export class AppearanceObserver {
     this.delegate = delegate
     this.element = element || delegate
     this.started = false
+    this.intersecting = false
 
     this.intersectionObserver = new IntersectionObserver(this.intersect)
   }
@@ -11,6 +12,7 @@ export class AppearanceObserver {
     if (!this.started) {
       this.started = true
       this.intersectionObserver.observe(this.element)
+      this.observeVisibility()
     }
   }
 
@@ -18,18 +20,40 @@ export class AppearanceObserver {
     if (this.started) {
       this.started = false
       this.intersectionObserver.unobserve(this.element)
+      this.unobserveVisibility()
     }
+  }
+
+  observeVisibility = () => {
+    document.addEventListener('visibilitychange', this.handleVisibilityChange)
+  }
+
+  unobserveVisibility = () => {
+    document.removeEventListener(
+      'visibilitychange',
+      this.handleVisibilityChange
+    )
   }
 
   intersect = entries => {
     entries.forEach(entry => {
       if (entry.target === this.element) {
-        if (entry.isIntersecting) {
+        if (entry.isIntersecting && document.visibilityState === 'visible') {
+          this.intersecting = true
           this.delegate.appearedInViewport()
         } else {
+          this.intersecting = false
           this.delegate.disappearedFromViewport()
         }
       }
     })
+  }
+
+  handleVisibilityChange = event => {
+    if (document.visibilityState === 'visible' && this.intersecting) {
+      this.delegate.appearedInViewport()
+    } else {
+      this.delegate.disappearedFromViewport()
+    }
   }
 }


### PR DESCRIPTION
# Feature

## Description

This PR addresses an optimization regarding the number of requests that `Updatable` possibly makes.

The rationale is this: it doesn't really make sense to keep elements that aren't visible up to date. this can be deferred, which defaults to lazy loading.

We have to distinguish 3 cases here:

- is visible - behavior as usual
- is not visible - ignore requests. Basically shouldUpdate == false
- transition from invisible to visible - pull and morph once, then listen as normal

## Implementation

I leaned on Turbo's solution here a bit, and introduced a separate `AppearanceObserver`. The thing I added to the regular `IntersectionObserver` is an observer for `document.visibilityState`. This means:

- not only hidden elements in the DOM tree of the opened browser tab
- but also generally elements that are in browser tabs that are currently closed/hidden

will _not_ trigger updates. When they come into view, e.g. by scrolling into the viewport, or switching browser tabs, they will perform a one-time update and then continue listening as normal.


In terms of view helpers, I only added an `observe_appearance` flag to keep this optional. The element will then observe both behaviors though.

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
