### PR TITLE
Add `observer` gem to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       actionpack (>= 5.2)
       actionview (>= 5.2)
       activesupport (>= 5.2)
+      observer (~> 0.1)
       railties (>= 5.2)
       thread-local (>= 1.1.0)
 
@@ -114,6 +115,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
+    observer (0.1.2)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)

--- a/cable_ready.gemspec
+++ b/cable_ready.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activesupport", rails_version
   gem.add_dependency "railties", rails_version
   gem.add_dependency "thread-local", ">= 1.1.0"
+  gem.add_dependency "observer", "~> 0.1"
 
   gem.add_development_dependency "magic_frozen_string_literal"
   gem.add_development_dependency "mocha"


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

Ruby 3.4 removes the `observer` gem from the standard gems which is why we have the declare the dependency explicitly now.

From https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/:

> ### Standard library updates
> RubyGems and Bundler warn if users do require the following gems without adding them to Gemfile or gemspec. This is because they will become the bundled gems in the future version of Ruby.

Fixes #293 

## Why should this be added

To provide Ruby 3.4+ support.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
