### PR TITLE
Isolate and namespace `CableReady::Installer`

### DIFF
--- a/lib/cable_ready/installer.rb
+++ b/lib/cable_ready/installer.rb
@@ -2,223 +2,250 @@
 
 require "cable_ready/version"
 
-### general utilities
+module CableReady
+  class Installer
+    include Thor::Base
+    include Thor::Actions
 
-def fetch(step_path, file)
-  relative_path = step_path + file
-  location = template_src + relative_path
+    source_root Dir.pwd
 
-  Pathname.new(location)
-end
+    ## Thor wrapper
 
-def complete_step(step)
-  create_file "tmp/cable_ready_installer/#{step}", verbose: false
-end
-
-def create_or_append(path, *args, &block)
-  FileUtils.touch(path)
-  append_file(path, *args, &block)
-end
-
-def current_template
-  ENV["LOCATION"].split("/").last.gsub(".rb", "")
-end
-
-def pack_path_missing?
-  return false unless pack_path.nil?
-  halt "#{friendly_pack_path} is missing. You need a valid application pack file to proceed."
-end
-
-def halt(message)
-  say "❌ #{message}", :red
-  create_file "tmp/cable_ready_installer/halt", verbose: false
-end
-
-def backup(path, delete: false)
-  if !path.exist?
-    yield
-    return
-  end
-
-  backup_path = Pathname.new("#{path}.bak")
-  old_path = path.relative_path_from(Rails.root).to_s
-  filename = path.to_path.split("/").last
-
-  if backup_path.exist?
-    if backup_path.read == path.read
-      path.delete if delete
-      yield
-      return
+    def self.create_file(...)
+      new.create_file(...)
     end
-    backup_path.delete
+
+    def self.append_file(...)
+      new.append_file(...)
+    end
+
+    def self.copy_file(...)
+      new.copy_file(...)
+    end
+
+    def self.say(...)
+      new.say(...)
+    end
+
+    ### general utilities
+
+    def self.fetch(step_path, file)
+      relative_path = step_path + file
+      location = template_src + relative_path
+
+      Pathname.new(location)
+    end
+
+    def self.complete_step(step)
+      create_file "tmp/cable_ready_installer/#{step}", verbose: false
+    end
+
+    def self.create_or_append(path, *args, &block)
+      FileUtils.touch(path)
+      append_file(path, *args, &block)
+    end
+
+    def self.current_template
+      ENV["LOCATION"].split("/").last.gsub(".rb", "")
+    end
+
+    def self.pack_path_missing?
+      return false unless pack_path.nil?
+      halt "#{friendly_pack_path} is missing. You need a valid application pack file to proceed."
+    end
+
+    def self.halt(message)
+      say "❌ #{message}", :red
+      create_file "tmp/cable_ready_installer/halt", verbose: false
+    end
+
+    def self.backup(path, delete: false)
+      if !path.exist?
+        yield
+        return
+      end
+
+      backup_path = Pathname.new("#{path}.bak")
+      old_path = path.relative_path_from(Rails.root).to_s
+      filename = path.to_path.split("/").last
+
+      if backup_path.exist?
+        if backup_path.read == path.read
+          path.delete if delete
+          yield
+          return
+        end
+        backup_path.delete
+      end
+
+      copy_file(path, backup_path, verbose: false)
+      path.delete if delete
+
+      yield
+
+      if path.read != backup_path.read
+        create_or_append(backups_path, "#{old_path}\n", verbose: false)
+      end
+      say "📦 #{old_path} backed up as #{filename}.bak"
+    end
+
+    def self.add_gem(name)
+      create_or_append(add_gem_list, "#{name}\n", verbose: false)
+      say "☑️  Added #{name} to the Gemfile"
+    end
+
+    def self.remove_gem(name)
+      create_or_append(remove_gem_list, "#{name}\n", verbose: false)
+      say "❎ Removed #{name} from Gemfile"
+    end
+
+    def self.add_package(name)
+      create_or_append(package_list, "#{name}\n", verbose: false)
+      say "☑️  Enqueued #{name} to be added to dependencies"
+    end
+
+    def self.add_dev_package(name)
+      create_or_append(dev_package_list, "#{name}\n", verbose: false)
+      say "☑️  Enqueued #{name} to be added to dev dependencies"
+    end
+
+    def self.drop_package(name)
+      create_or_append(drop_package_list, "#{name}\n", verbose: false)
+      say "❎ Enqueued #{name} to be removed from dependencies"
+    end
+
+    def self.gemfile_hash
+      Digest::MD5.hexdigest(gemfile_path.read)
+    end
+
+    ### memoized values
+
+    def self.cr_npm_version
+      @cr_npm_version ||= CableReady::VERSION.gsub(".pre", "-pre")
+    end
+
+    def self.package_json
+      @package_json ||= Rails.root.join("package.json")
+    end
+
+    def self.entrypoint
+      @entrypoint ||= File.read("tmp/cable_ready_installer/entrypoint")
+    end
+
+    def self.bundler
+      @bundler ||= File.read("tmp/cable_ready_installer/bundler")
+    end
+
+    def self.config_path
+      @config_path ||= Rails.root.join(entrypoint, "config")
+    end
+
+    def self.importmap_path
+      @importmap_path ||= Rails.root.join("config/importmap.rb")
+    end
+
+    def self.friendly_importmap_path
+      @friendly_importmap_path ||= importmap_path.relative_path_from(Rails.root).to_s
+    end
+
+    def self.pack
+      @pack ||= pack_path.read
+    end
+
+    def self.friendly_pack_path
+      @friendly_pack_path ||= pack_path.relative_path_from(Rails.root).to_s
+    end
+
+    def self.pack_path
+      @pack_path ||= [
+        Rails.root.join(entrypoint, "application.js"),
+        Rails.root.join(entrypoint, "packs/application.js"),
+        Rails.root.join(entrypoint, "entrypoints/application.js")
+      ].find(&:exist?)
+    end
+
+    def self.package_list
+      @package_list ||= Rails.root.join("tmp/cable_ready_installer/npm_package_list")
+    end
+
+    def self.dev_package_list
+      @dev_package_list ||= Rails.root.join("tmp/cable_ready_installer/npm_dev_package_list")
+    end
+
+    def self.drop_package_list
+      @drop_package_list ||= Rails.root.join("tmp/cable_ready_installer/drop_npm_package_list")
+    end
+
+    def self.template_src
+      @template_src ||= File.read("tmp/cable_ready_installer/template_src")
+    end
+
+    def self.controllers_path
+      @controllers_path ||= Rails.root.join(entrypoint, "controllers")
+    end
+
+    def self.gemfile_path
+      @gemfile_path ||= Rails.root.join("Gemfile")
+    end
+
+    def self.gemfile
+      @gemfile ||= gemfile_path.read
+    end
+
+    def self.prefix
+      # standard:disable Style/RedundantStringEscape
+      @prefix ||= {
+        "vite" => "..\/",
+        "webpacker" => "",
+        "shakapacker" => "",
+        "importmap" => "",
+        "esbuild" => ".\/"
+      }[bundler]
+      # standard:enable Style/RedundantStringEscape
+    end
+
+    def self.application_record_path
+      @application_record_path ||= Rails.root.join("app/models/application_record.rb")
+    end
+
+    def self.action_cable_initializer_path
+      @action_cable_initializer_path ||= Rails.root.join("config/initializers/action_cable.rb")
+    end
+
+    def self.action_cable_initializer_working_path
+      @action_cable_initializer_working_path ||= Rails.root.join(working, "action_cable.rb")
+    end
+
+    def self.development_path
+      @development_path ||= Rails.root.join("config/environments/development.rb")
+    end
+
+    def self.development_working_path
+      @development_working_path ||= Rails.root.join(working, "development.rb")
+    end
+
+    def self.backups_path
+      @backups_path ||= Rails.root.join("tmp/cable_ready_installer/backups")
+    end
+
+    def self.add_gem_list
+      @add_gem_list ||= Rails.root.join("tmp/cable_ready_installer/add_gem_list")
+    end
+
+    def self.remove_gem_list
+      @remove_gem_list ||= Rails.root.join("tmp/cable_ready_installer/remove_gem_list")
+    end
+
+    def self.options_path
+      @options_path ||= Rails.root.join("tmp/cable_ready_installer/options")
+    end
+
+    def self.options
+      @options ||= YAML.safe_load(File.read(options_path))
+    end
+
+    def self.working
+      @working ||= Rails.root.join("tmp/cable_ready_installer/working")
+    end
   end
-
-  copy_file(path, backup_path, verbose: false)
-  path.delete if delete
-
-  yield
-
-  if path.read != backup_path.read
-    create_or_append(backups_path, "#{old_path}\n", verbose: false)
-  end
-  say "📦 #{old_path} backed up as #{filename}.bak"
-end
-
-def add_gem(name)
-  create_or_append(add_gem_list, "#{name}\n", verbose: false)
-  say "☑️  Added #{name} to the Gemfile"
-end
-
-def remove_gem(name)
-  create_or_append(remove_gem_list, "#{name}\n", verbose: false)
-  say "❎ Removed #{name} from Gemfile"
-end
-
-def add_package(name)
-  create_or_append(package_list, "#{name}\n", verbose: false)
-  say "☑️  Enqueued #{name} to be added to dependencies"
-end
-
-def add_dev_package(name)
-  create_or_append(dev_package_list, "#{name}\n", verbose: false)
-  say "☑️  Enqueued #{name} to be added to dev dependencies"
-end
-
-def drop_package(name)
-  create_or_append(drop_package_list, "#{name}\n", verbose: false)
-  say "❎ Enqueued #{name} to be removed from dependencies"
-end
-
-def gemfile_hash
-  Digest::MD5.hexdigest(gemfile_path.read)
-end
-
-### memoized values
-
-def cr_npm_version
-  @cr_npm_version ||= CableReady::VERSION.gsub(".pre", "-pre")
-end
-
-def package_json
-  @package_json ||= Rails.root.join("package.json")
-end
-
-def entrypoint
-  @entrypoint ||= File.read("tmp/cable_ready_installer/entrypoint")
-end
-
-def bundler
-  @bundler ||= File.read("tmp/cable_ready_installer/bundler")
-end
-
-def config_path
-  @config_path ||= Rails.root.join(entrypoint, "config")
-end
-
-def importmap_path
-  @importmap_path ||= Rails.root.join("config/importmap.rb")
-end
-
-def friendly_importmap_path
-  @friendly_importmap_path ||= importmap_path.relative_path_from(Rails.root).to_s
-end
-
-def pack
-  @pack ||= pack_path.read
-end
-
-def friendly_pack_path
-  @friendly_pack_path ||= pack_path.relative_path_from(Rails.root).to_s
-end
-
-def pack_path
-  @pack_path ||= [
-    Rails.root.join(entrypoint, "application.js"),
-    Rails.root.join(entrypoint, "packs/application.js"),
-    Rails.root.join(entrypoint, "entrypoints/application.js")
-  ].find(&:exist?)
-end
-
-def package_list
-  @package_list ||= Rails.root.join("tmp/cable_ready_installer/npm_package_list")
-end
-
-def dev_package_list
-  @dev_package_list ||= Rails.root.join("tmp/cable_ready_installer/npm_dev_package_list")
-end
-
-def drop_package_list
-  @drop_package_list ||= Rails.root.join("tmp/cable_ready_installer/drop_npm_package_list")
-end
-
-def template_src
-  @template_src ||= File.read("tmp/cable_ready_installer/template_src")
-end
-
-def controllers_path
-  @controllers_path ||= Rails.root.join(entrypoint, "controllers")
-end
-
-def gemfile_path
-  @gemfile_path ||= Rails.root.join("Gemfile")
-end
-
-def gemfile
-  @gemfile ||= gemfile_path.read
-end
-
-def prefix
-  # standard:disable Style/RedundantStringEscape
-  @prefix ||= {
-    "vite" => "..\/",
-    "webpacker" => "",
-    "shakapacker" => "",
-    "importmap" => "",
-    "esbuild" => ".\/"
-  }[bundler]
-  # standard:enable Style/RedundantStringEscape
-end
-
-def application_record_path
-  @application_record_path ||= Rails.root.join("app/models/application_record.rb")
-end
-
-def action_cable_initializer_path
-  @action_cable_initializer_path ||= Rails.root.join("config/initializers/action_cable.rb")
-end
-
-def action_cable_initializer_working_path
-  @action_cable_initializer_working_path ||= Rails.root.join(working, "action_cable.rb")
-end
-
-def development_path
-  @development_path ||= Rails.root.join("config/environments/development.rb")
-end
-
-def development_working_path
-  @development_working_path ||= Rails.root.join(working, "development.rb")
-end
-
-def backups_path
-  @backups_path ||= Rails.root.join("tmp/cable_ready_installer/backups")
-end
-
-def add_gem_list
-  @add_gem_list ||= Rails.root.join("tmp/cable_ready_installer/add_gem_list")
-end
-
-def remove_gem_list
-  @remove_gem_list ||= Rails.root.join("tmp/cable_ready_installer/remove_gem_list")
-end
-
-def options_path
-  @options_path ||= Rails.root.join("tmp/cable_ready_installer/options")
-end
-
-def options
-  @options ||= YAML.safe_load(File.read(options_path))
-end
-
-def working
-  @working ||= Rails.root.join("tmp/cable_ready_installer/working")
 end

--- a/lib/install/action_cable.rb
+++ b/lib/install/action_cable.rb
@@ -6,11 +6,11 @@ require "cable_ready/installer"
 if defined?(ActionCable::Engine)
   say "✅ ActionCable::Engine is loaded and in scope"
 else
-  halt "ActionCable::Engine is not loaded, please add or uncomment `require \"action_cable/engine\"` to your `config/application.rb`"
+  CableReady::Installer.halt "ActionCable::Engine is not loaded, please add or uncomment `require \"action_cable/engine\"` to your `config/application.rb`"
   return
 end
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 # verify that the Action Cable pubsub config is created
 cable_config = Rails.root.join("config/cable.yml")
@@ -35,7 +35,7 @@ elsif yaml["development"]["adapter"] == "async"
     "url" => "<%= ENV.fetch(\"REDIS_URL\") { \"redis://localhost:6379/1\" } %>",
     "channel_prefix" => "#{app_name}_development"
   }
-  backup(cable_config) do
+  CableReady::Installer.backup(cable_config) do
     cable_config.write(yaml.to_yaml)
   end
   say "✅ config/cable.yml was updated to use the redis adapter in development"
@@ -44,24 +44,24 @@ else
 end
 
 if Rails::VERSION::MAJOR >= 7
-  add_gem "redis@~> 5"
+  CableReady::Installer.add_gem "redis@~> 5"
 else
-  add_gem "redis@~> 4"
+  CableReady::Installer.add_gem "redis@~> 4"
 end
 
 # install action-cable-redis-backport gem if using Action Cable < 7.1
 unless ActionCable::VERSION::MAJOR >= 7 && ActionCable::VERSION::MINOR >= 1
-  if !gemfile.match?(/gem ['"]action-cable-redis-backport['"]/)
-    add_gem "action-cable-redis-backport@~> 1"
+  if !CableReady::Installer.gemfile.match?(/gem ['"]action-cable-redis-backport['"]/)
+    CableReady::Installer.add_gem "action-cable-redis-backport@~> 1"
   end
 end
 
 # verify that the Action Cable channels folder and consumer class is available
 step_path = "/app/javascript/channels/"
-channels_path = Rails.root.join(entrypoint, "channels")
-consumer_src = fetch(step_path, "consumer.js.tt")
+channels_path = Rails.root.join(CableReady::Installer.entrypoint, "channels")
+consumer_src = CableReady::Installer.fetch(step_path, "consumer.js.tt")
 consumer_path = channels_path / "consumer.js"
-index_src = fetch(step_path, "index.js.#{bundler}.tt")
+index_src = CableReady::Installer.fetch(step_path, "index.js.#{CableReady::Installer.bundler}.tt")
 index_path = channels_path / "index.js"
 friendly_index_path = index_path.relative_path_from(Rails.root).to_s
 
@@ -73,7 +73,7 @@ if index_path.exist?
   if index_path.read == index_src.read
     say "✅ #{friendly_index_path} is present"
   else
-    backup(index_path) do
+    CableReady::Installer.backup(index_path) do
       copy_file(index_src, index_path, verbose: false)
     end
     say "✅ #{friendly_index_path} has been created"
@@ -85,43 +85,43 @@ end
 # import Action Cable channels into application pack
 channels_pattern = /import ['"](\.\.\/|\.\/)?channels['"]/
 channels_commented_pattern = /\s*\/\/\s*#{channels_pattern}/
-channel_import = "import \"#{prefix}channels\"\n"
+channel_import = "import \"#{CableReady::Installer.prefix}channels\"\n"
 
-if pack.match?(channels_pattern)
-  if pack.match?(channels_commented_pattern)
-    proceed = if options.key? "uncomment"
-      options["uncomment"]
+if CableReady::Installer.pack.match?(channels_pattern)
+  if CableReady::Installer.pack.match?(channels_commented_pattern)
+    proceed = if CableReady::Installer.options.key? "uncomment"
+      CableReady::Installer.options["uncomment"]
     else
       !no?("✨ Action Cable seems to be commented out in your application.js. Do you want to uncomment it? (Y/n)")
     end
 
     if proceed
       # uncomment_lines only works with Ruby comments 🙄
-      lines = pack_path.readlines
+      lines = CableReady::Installer.pack_path.readlines
       matches = lines.select { |line| line =~ channels_commented_pattern }
       lines[lines.index(matches.last).to_i] = channel_import
-      pack_path.write lines.join
-      say "✅ channels imported in #{friendly_pack_path}"
+      CableReady::Installer.pack_path.write lines.join
+      say "✅ channels imported in #{CableReady::Installer.friendly_pack_path}"
     else
       say "🤷 your Action Cable channels are not being imported in your application.js. We trust that you have a reason for this."
     end
   else
-    say "✅ channels imported in #{friendly_pack_path}"
+    say "✅ channels imported in #{CableReady::Installer.friendly_pack_path}"
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, channel_import
-  pack_path.write lines.join
-  say "✅ channels imported in #{friendly_pack_path}"
+  CableReady::Installer.pack_path.write lines.join
+  say "✅ channels imported in #{CableReady::Installer.friendly_pack_path}"
 end
 
 # create working copy of Action Cable initializer in tmp
-if action_cable_initializer_path.exist?
-  FileUtils.cp(action_cable_initializer_path, action_cable_initializer_working_path)
+if CableReady::Installer.action_cable_initializer_path.exist?
+  FileUtils.cp(CableReady::Installer.action_cable_initializer_path, CableReady::Installer.action_cable_initializer_working_path)
 else
   # create Action Cable initializer if it doesn't already exist
-  create_file(action_cable_initializer_working_path, verbose: false) do
+  create_file(CableReady::Installer.action_cable_initializer_working_path, verbose: false) do
     <<~RUBY
       # frozen_string_literal: true
 
@@ -131,8 +131,8 @@ else
 end
 
 # silence notoriously chatty Action Cable logs
-if !action_cable_initializer_working_path.read.match?(/^[^#]*ActionCable.server.config.logger/)
-  append_file(action_cable_initializer_working_path, verbose: false) do
+if !CableReady::Installer.action_cable_initializer_working_path.read.match?(/^[^#]*ActionCable.server.config.logger/)
+  append_file(CableReady::Installer.action_cable_initializer_working_path, verbose: false) do
     <<~RUBY
       ActionCable.server.config.logger = Logger.new(nil)
 
@@ -141,4 +141,4 @@ if !action_cable_initializer_working_path.read.match?(/^[^#]*ActionCable.server.
   say "✅ Action Cable logger silenced for performance and legibility"
 end
 
-complete_step :action_cable
+CableReady::Installer.complete_step :action_cable

--- a/lib/install/bundle.rb
+++ b/lib/install/bundle.rb
@@ -2,14 +2,14 @@
 
 require "cable_ready/installer"
 
-hash = gemfile_hash
+hash = CableReady::Installer.gemfile_hash
 
 # run bundle only when gems are waiting to be added or removed
-add = add_gem_list.exist? ? add_gem_list.readlines.map(&:chomp) : []
-remove = remove_gem_list.exist? ? remove_gem_list.readlines.map(&:chomp) : []
+add = CableReady::Installer.add_gem_list.exist? ? CableReady::Installer.add_gem_list.readlines.map(&:chomp) : []
+remove = CableReady::Installer.remove_gem_list.exist? ? CableReady::Installer.remove_gem_list.readlines.map(&:chomp) : []
 
 if add.present? || remove.present?
-  lines = gemfile_path.readlines
+  lines = CableReady::Installer.gemfile_path.readlines
 
   remove.each do |name|
     index = lines.index { |line| line =~ /gem ['"]#{name}['"]/ }
@@ -40,15 +40,15 @@ if add.present? || remove.present?
     end
   end
 
-  gemfile_path.write lines.join
+  CableReady::Installer.gemfile_path.write lines.join
 
-  bundle_command("install --quiet", "BUNDLE_IGNORE_MESSAGES" => "1") if hash != gemfile_hash
+  bundle_command("install --quiet", "BUNDLE_IGNORE_MESSAGES" => "1") if hash != CableReady::Installer.gemfile_hash
 end
 
-FileUtils.cp(development_working_path, development_path)
+FileUtils.cp(CableReady::Installer.development_working_path, CableReady::Installer.development_path)
 say "✅ development environment configuration installed"
 
-FileUtils.cp(action_cable_initializer_working_path, action_cable_initializer_path)
+FileUtils.cp(CableReady::Installer.action_cable_initializer_working_path, CableReady::Installer.action_cable_initializer_path)
 say "✅ Action Cable initializer installed"
 
-complete_step :bundle
+CableReady::Installer.complete_step :bundle

--- a/lib/install/compression.rb
+++ b/lib/install/compression.rb
@@ -2,26 +2,26 @@
 
 require "cable_ready/installer"
 
-initializer = action_cable_initializer_working_path.read
+initializer = CableReady::Installer.action_cable_initializer_working_path.read
 
 proceed = false
 
 if initializer.exclude? "PermessageDeflate.configure"
-  proceed = if options.key? "compression"
-    options["compression"]
+  proceed = if CableReady::Installer.options.key? "compression"
+    CableReady::Installer.options["compression"]
   else
     !no?("✨ Configure Action Cable to compress your WebSocket traffic with gzip? (Y/n)")
   end
 end
 
 if proceed
-  if !gemfile.match?(/gem ['"]permessage_deflate['"]/)
-    add_gem "permessage_deflate@>= 0.1"
+  if !CableReady::Installer.gemfile.match?(/gem ['"]permessage_deflate['"]/)
+    CableReady::Installer.add_gem "permessage_deflate@>= 0.1"
   end
 
   # add permessage_deflate config to Action Cable initializer
   if initializer.exclude? "PermessageDeflate.configure"
-    create_or_append(action_cable_initializer_working_path, verbose: false) do
+    CableReady::Installer.create_or_append(CableReady::Installer.action_cable_initializer_working_path, verbose: false) do
       <<~RUBY
         module ActionCable
           module Connection
@@ -48,4 +48,4 @@ if proceed
   end
 end
 
-complete_step :compression
+CableReady::Installer.complete_step :compression

--- a/lib/install/config.rb
+++ b/lib/install/config.rb
@@ -2,38 +2,38 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 step_path = "/app/javascript/config/"
-index_src = fetch(step_path, "index.js.tt")
-index_path = config_path / "index.js"
-cable_ready_src = fetch(step_path, "cable_ready.js.tt")
-cable_ready_path = config_path / "cable_ready.js"
+index_src = CableReady::Installer.fetch(step_path, "index.js.tt")
+index_path = CableReady::Installer.config_path / "index.js"
+cable_ready_src = CableReady::Installer.fetch(step_path, "cable_ready.js.tt")
+cable_ready_path = CableReady::Installer.config_path / "cable_ready.js"
 
-empty_directory config_path unless config_path.exist?
+empty_directory CableReady::Installer.config_path unless CableReady::Installer.config_path.exist?
 
-copy_file(index_src, index_path) unless index_path.exist?
+CableReady::Installer.copy_file(index_src, index_path) unless index_path.exist?
 
 index_pattern = /import ['"](\.\.\/|\.\/)?config['"]/
 index_commented_pattern = /\s*\/\/\s*#{index_pattern}/
-index_import = "import \"#{prefix}config\"\n"
+index_import = "import \"#{CableReady::Installer.prefix}config\"\n"
 
-if pack.match?(index_pattern)
-  if pack.match?(index_commented_pattern)
-    lines = pack_path.readlines
+if CableReady::Installer.pack.match?(index_pattern)
+  if CableReady::Installer.pack.match?(index_commented_pattern)
+    lines = CableReady::Installer.pack_path.readlines
     matches = lines.select { |line| line =~ index_commented_pattern }
     lines[lines.index(matches.last).to_i] = index_import
-    pack_path.write lines.join
+    CableReady::Installer.pack_path.write lines.join
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, index_import
-  pack_path.write lines.join
+  CableReady::Installer.pack_path.write lines.join
 end
-say "✅ CableReady configs will be imported in #{friendly_pack_path}"
+say "✅ CableReady configs will be imported in #{CableReady::Installer.friendly_pack_path}"
 
 # create entrypoint/config/cable_ready.js and make sure it's imported in application.js
-copy_file(cable_ready_src, cable_ready_path) unless cable_ready_path.exist?
+CableReady::Installer.copy_file(cable_ready_src, cable_ready_path) unless cable_ready_path.exist?
 
-complete_step :config
+CableReady::Installer.complete_step :config

--- a/lib/install/development.rb
+++ b/lib/install/development.rb
@@ -3,32 +3,32 @@
 require "cable_ready/installer"
 
 # mutate working copy of development.rb to avoid bundle alerts
-FileUtils.cp(development_path, development_working_path)
+FileUtils.cp(CableReady::Installer.development_path, CableReady::Installer.development_working_path)
 
 # add default_url_options to development.rb for Action Mailer
 if defined?(ActionMailer)
-  lines = development_working_path.readlines
+  lines = CableReady::Installer.development_working_path.readlines
   if lines.find { |line| line.include?("config.action_mailer.default_url_options") }
     say "⏩ Action Mailer default_url_options already defined. Skipping."
   else
     index = lines.index { |line| line =~ /^Rails.application.configure do/ }
     lines.insert index + 1, "  config.action_mailer.default_url_options = {host: \"localhost\", port: 3000}\n\n"
-    development_working_path.write lines.join
+    CableReady::Installer.development_working_path.write lines.join
 
     say "✅ Action Mailer default_url_options defined"
   end
 end
 
 # add default_url_options to development.rb for Action Controller
-lines = development_working_path.readlines
+lines = CableReady::Installer.development_working_path.readlines
 if lines.find { |line| line.include?("config.action_controller.default_url_options") }
   say "⏩ Action Controller default_url_options already defined. Skipping."
 else
   index = lines.index { |line| line =~ /^Rails.application.configure do/ }
   lines.insert index + 1, "  config.action_controller.default_url_options = {host: \"localhost\", port: 3000}\n"
-  development_working_path.write lines.join
+  CableReady::Installer.development_working_path.write lines.join
 
   say "✅ Action Controller default_url_options defined"
 end
 
-complete_step :development
+CableReady::Installer.complete_step :development

--- a/lib/install/esbuild.rb
+++ b/lib/install/esbuild.rb
@@ -2,47 +2,47 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 # verify that all critical dependencies are up to date; if not, queue for later
-lines = package_json.readlines
+lines = CableReady::Installer.package_json.readlines
 
 if !lines.index { |line| line =~ /^\s*["']esbuild-rails["']: ["']\^1.0.3["']/ }
-  add_package "esbuild-rails@^1.0.3"
+  CableReady::Installer.add_package "esbuild-rails@^1.0.3"
 end
 
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus["']:/ }
-  add_package "@hotwired/stimulus@^3.2"
+  CableReady::Installer.add_package "@hotwired/stimulus@^3.2"
 end
 # copy esbuild.config.mjs to app root
-esbuild_src = fetch("/", "esbuild.config.mjs.tt")
+esbuild_src = CableReady::Installer.fetch("/", "esbuild.config.mjs.tt")
 esbuild_path = Rails.root.join("esbuild.config.mjs")
 if esbuild_path.exist?
   if esbuild_path.read == esbuild_src.read
     say "✅ esbuild.config.mjs present in app root"
   else
-    backup(esbuild_path) do
-      template(esbuild_src, esbuild_path, verbose: false, entrypoint: entrypoint)
+    CableReady::Installer.backup(esbuild_path) do
+      template(esbuild_src, esbuild_path, verbose: false, entrypoint: CableReady::Installer.entrypoint)
     end
   end
 else
-  template(esbuild_src, esbuild_path, entrypoint: entrypoint)
+  template(esbuild_src, esbuild_path, entrypoint: CableReady::Installer.entrypoint)
 end
 
 step_path = "/app/javascript/controllers/"
-application_js_src = fetch(step_path, "application.js.tt")
-application_js_path = controllers_path / "application.js"
-index_src = fetch(step_path, "index.js.esbuild.tt")
-index_path = controllers_path / "index.js"
+application_js_src = CableReady::Installer.fetch(step_path, "application.js.tt")
+application_js_path = CableReady::Installer.controllers_path / "application.js"
+index_src = CableReady::Installer.fetch(step_path, "index.js.esbuild.tt")
+index_path = CableReady::Installer.controllers_path / "index.js"
 friendly_index_path = index_path.relative_path_from(Rails.root).to_s
 
 # create entrypoint/controllers, if necessary
-empty_directory controllers_path unless controllers_path.exist?
+empty_directory CableReady::Installer.controllers_path unless CableReady::Installer.controllers_path.exist?
 
 # configure Stimulus application superclass to import Action Cable consumer
 friendly_application_js_path = application_js_path.relative_path_from(Rails.root).to_s
 if application_js_path.exist?
-  backup(application_js_path) do
+  CableReady::Installer.backup(application_js_path) do
     if application_js_path.read.include?("import consumer")
       say "✅ #{friendly_application_js_path} is present"
     else
@@ -52,12 +52,12 @@ if application_js_path.exist?
     end
   end
 else
-  copy_file(application_js_src, application_js_path)
+  CableReady::Installer.copy_file(application_js_src, application_js_path)
 end
 
 if index_path.exist?
   if index_path.read != index_src.read
-    backup(index_path, delete: true) do
+    CableReady::Installer.backup(index_path, delete: true) do
       copy_file(index_src, index_path, verbose: false)
     end
   end
@@ -69,33 +69,33 @@ say "✅ #{friendly_index_path} has been created"
 controllers_pattern = /import ['"].\/controllers['"]/
 controllers_commented_pattern = /\s*\/\/\s*#{controllers_pattern}/
 
-if pack.match?(controllers_pattern)
-  if pack.match?(controllers_commented_pattern)
-    proceed = if options.key? "uncomment"
-      options["uncomment"]
+if CableReady::Installer.pack.match?(controllers_pattern)
+  if CableReady::Installer.pack.match?(controllers_commented_pattern)
+    proceed = if CableReady::Installer.options.key? "uncomment"
+      CableReady::Installer.options["uncomment"]
     else
       !no?("✨ Stimulus seems to be commented out in your application.js. Do you want to import your controllers? (Y/n)")
     end
 
     if proceed
       # uncomment_lines only works with Ruby comments 🙄
-      lines = pack_path.readlines
+      lines = CableReady::Installer.pack_path.readlines
       matches = lines.select { |line| line =~ controllers_commented_pattern }
       lines[lines.index(matches.last).to_i] = "import \".\/controllers\"\n" # standard:disable Style/RedundantStringEscape
-      pack_path.write lines.join
-      say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+      CableReady::Installer.pack_path.write lines.join
+      say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
     else
       say "🤷 your Stimulus controllers are not being imported in your application.js. We trust that you have a reason for this."
     end
   else
-    say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+    say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, "import \".\/controllers\"\n" # standard:disable Style/RedundantStringEscape
-  pack_path.write lines.join
-  say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+  CableReady::Installer.pack_path.write lines.join
+  say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
 end
 
-complete_step :esbuild
+CableReady::Installer.complete_step :esbuild

--- a/lib/install/importmap.rb
+++ b/lib/install/importmap.rb
@@ -2,69 +2,69 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
-if !importmap_path.exist?
-  halt "#{friendly_importmap_path} is missing. You need a valid importmap config file to proceed."
+if !CableReady::Installer.importmap_path.exist?
+  CableReady::Installer.halt "#{friendly_CableReady::Installer.importmap_path} is missing. You need a valid importmap config file to proceed."
   return
 end
 
-importmap = importmap_path.read
+importmap = CableReady::Installer.importmap_path.read
 
-backup(importmap_path) do
-  if !importmap.include?("pin_all_from \"#{entrypoint}/controllers\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
-      pin_all_from "#{entrypoint}/controllers", under: "controllers"
+CableReady::Installer.backup(CableReady::Installer.importmap_path) do
+  if !importmap.include?("pin_all_from \"#{CableReady::Installer.entrypoint}/controllers\"")
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
+      pin_all_from "#{CableReady::Installer.entrypoint}/controllers", under: "controllers"
     RUBY
     say "✅ pin controllers folder"
   end
 
-  if !importmap.include?("pin_all_from \"#{entrypoint}/channels\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
-      pin_all_from "#{entrypoint}/channels", under: "channels"
+  if !importmap.include?("pin_all_from \"#{CableReady::Installer.entrypoint}/channels\"")
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
+      pin_all_from "#{CableReady::Installer.entrypoint}/channels", under: "channels"
     RUBY
     say "✅ pin channels folder"
   end
 
-  if !importmap.include?("pin_all_from \"#{entrypoint}/config\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
-      pin_all_from "#{entrypoint}/config", under: "config"
+  if !importmap.include?("pin_all_from \"#{CableReady::Installer.entrypoint}/config\"")
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
+      pin_all_from "#{CableReady::Installer.entrypoint}/config", under: "config"
     RUBY
     say "✅ pin config folder"
   end
 
   if !importmap.include?("pin \"@rails/actioncable\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
       pin "@rails/actioncable", to: "actioncable.esm.js", preload: true
     RUBY
     say "✅ pin Action Cable"
   end
 
   if !importmap.include?("pin \"cable_ready\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
       pin "cable_ready", to: "cable_ready.js", preload: true
     RUBY
     say "✅ pin CableReady"
   end
 
   if !importmap.include?("pin \"morphdom\"")
-    append_file(importmap_path, <<~RUBY, verbose: false)
+    append_file(CableReady::Installer.importmap_path, <<~RUBY, verbose: false)
       pin "morphdom", to: "https://ga.jspm.io/npm:morphdom@2.6.1/dist/morphdom.js", preload: true
     RUBY
     say "✅ pin morphdom"
   end
 end
 
-application_js_src = fetch("/", "app/javascript/controllers/application.js.tt")
-application_js_path = controllers_path / "application.js"
-index_src = fetch("/", "app/javascript/controllers/index.js.importmap.tt")
-index_path = controllers_path / "index.js"
+application_js_src = CableReady::Installer.fetch("/", "app/javascript/controllers/application.js.tt")
+application_js_path = CableReady::Installer.controllers_path / "application.js"
+index_src = CableReady::Installer.fetch("/", "app/javascript/controllers/index.js.importmap.tt")
+index_path = CableReady::Installer.controllers_path / "index.js"
 
 # create entrypoint/controllers, as well as the index, application and application_controller
-empty_directory controllers_path unless controllers_path.exist?
+empty_directory CableReady::Installer.controllers_path unless CableReady::Installer.controllers_path.exist?
 
 # configure Stimulus application superclass to import Action Cable consumer
-backup(application_js_path) do
+CableReady::Installer.backup(application_js_path) do
   if application_js_path.exist?
     friendly_application_js_path = application_js_path.relative_path_from(Rails.root).to_s
     if application_js_path.read.include?("import consumer")
@@ -84,7 +84,7 @@ if index_path.exist?
   if index_path.read == index_src.read
     say "✅ #{friendly_index_path} is present"
   else
-    backup(index_path, delete: true) do
+    CableReady::Installer.backup(index_path, delete: true) do
       copy_file(index_src, index_path, verbose: false)
     end
     say "✅ #{friendly_index_path} has been created"
@@ -93,4 +93,4 @@ else
   copy_file(index_src, index_path)
 end
 
-complete_step :importmap
+CableReady::Installer.complete_step :importmap

--- a/lib/install/initializers.rb
+++ b/lib/install/initializers.rb
@@ -2,7 +2,7 @@
 
 require "cable_ready/installer"
 
-cr_initializer_src = fetch("/", "config/initializers/cable_ready.rb")
+cr_initializer_src = CableReady::Installer.fetch("/", "config/initializers/cable_ready.rb")
 cr_initializer_path = Rails.root.join("config/initializers/cable_ready.rb")
 
 if !cr_initializer_path.exist?
@@ -12,4 +12,4 @@ else
   say "⏩ config/initializers/cable_ready.rb already exists. Skipping."
 end
 
-complete_step :initializers
+CableReady::Installer.complete_step :initializers

--- a/lib/install/npm_packages.rb
+++ b/lib/install/npm_packages.rb
@@ -2,12 +2,12 @@
 
 require "cable_ready/installer"
 
-lines = package_json.readlines
+lines = CableReady::Installer.package_json.readlines
 
-if !lines.index { |line| line =~ /^\s*["']cable_ready["']: ["'].*#{cr_npm_version}["']/ }
-  add_package "cable_ready@#{cr_npm_version}"
+if !lines.index { |line| line =~ /^\s*["']cable_ready["']: ["'].*#{CableReady::Installer.cr_npm_version}["']/ }
+  CableReady::Installer.add_package "cable_ready@#{CableReady::Installer.cr_npm_version}"
 else
   say "⏩ cable_ready npm package is already present"
 end
 
-complete_step :npm_packages
+CableReady::Installer.complete_step :npm_packages

--- a/lib/install/shakapacker.rb
+++ b/lib/install/shakapacker.rb
@@ -2,30 +2,30 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 # verify that all critical dependencies are up to date; if not, queue for later
-lines = package_json.readlines
+lines = CableReady::Installer.package_json.readlines
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus["']:/ }
-  add_package "@hotwired/stimulus@^3.2"
+  CableReady::Installer.add_package "@hotwired/stimulus@^3.2"
 else
   say "⏩ @hotwired/stimulus npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus-webpack-helpers["']: ["']\^1.0.1["']/ }
-  add_package "@hotwired/stimulus-webpack-helpers@^1.0.1"
+  CableReady::Installer.add_package "@hotwired/stimulus-webpack-helpers@^1.0.1"
 else
   say "⏩ @hotwired/stimulus-webpack-helpers npm package is already present. Skipping."
 end
 
 step_path = "/app/javascript/controllers/"
-application_js_src = fetch(step_path, "application.js.tt")
-application_js_path = controllers_path / "application.js"
-index_src = fetch(step_path, "index.js.shakapacker.tt")
-index_path = controllers_path / "index.js"
+application_js_src = CableReady::Installer.fetch(step_path, "application.js.tt")
+application_js_path = CableReady::Installer.controllers_path / "application.js"
+index_src = CableReady::Installer.fetch(step_path, "index.js.shakapacker.tt")
+index_path = CableReady::Installer.controllers_path / "index.js"
 
 # create entrypoint/controllers, as well as the index, application and application_controller
-empty_directory controllers_path unless controllers_path.exist?
+empty_directory CableReady::Installer.controllers_path unless CableReady::Installer.controllers_path.exist?
 
 copy_file(application_js_src, application_js_path) unless application_js_path.exist?
 copy_file(index_src, index_path) unless index_path.exist?
@@ -33,33 +33,33 @@ copy_file(index_src, index_path) unless index_path.exist?
 controllers_pattern = /import ['"]controllers['"]/
 controllers_commented_pattern = /\s*\/\/\s*#{controllers_pattern}/
 
-if pack.match?(controllers_pattern)
-  if pack.match?(controllers_commented_pattern)
-    proceed = if options.key? "uncomment"
-      options["uncomment"]
+if CableReady::Installer.pack.match?(controllers_pattern)
+  if CableReady::Installer.pack.match?(controllers_commented_pattern)
+    proceed = if CableReady::Installer.options.key? "uncomment"
+      CableReady::Installer.options["uncomment"]
     else
       !no?("✨ Do you want to import your Stimulus controllers in application.js? (Y/n)")
     end
 
     if proceed
       # uncomment_lines only works with Ruby comments 🙄
-      lines = pack_path.readlines
+      lines = CableReady::Installer.pack_path.readlines
       matches = lines.select { |line| line =~ controllers_commented_pattern }
       lines[lines.index(matches.last).to_i] = "import \"controllers\"\n"
-      pack_path.write lines.join
-      say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+      CableReady::Installer.pack_path.write lines.join
+      say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
     else
       say "🤷 your Stimulus controllers are not being imported in your application.js. We trust that you have a reason for this."
     end
   else
-    say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+    say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, "import \"controllers\"\n"
-  pack_path.write lines.join
-  say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+  CableReady::Installer.pack_path.write lines.join
+  say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
 end
 
-complete_step :shakapacker
+CableReady::Installer.complete_step :shakapacker

--- a/lib/install/spring.rb
+++ b/lib/install/spring.rb
@@ -5,11 +5,11 @@ require "cable_ready/installer"
 spring_pattern = /^[^#]*gem ["']spring["']/
 
 proceed = false
-lines = gemfile_path.readlines
+lines = CableReady::Installer.gemfile_path.readlines
 
 if lines.index { |line| line =~ spring_pattern }
-  proceed = if options.key? "spring"
-    options["spring"]
+  proceed = if CableReady::Installer.options.key? "spring"
+    CableReady::Installer.options["spring"]
   else
     !no?("✨ Would you like to disable the spring gem? \nIt's been removed from Rails 7, and is the frequent culprit behind countless mystery bugs. (Y/n)")
   end
@@ -22,7 +22,7 @@ if proceed
   bin_rails_pattern = /^[^#]*load File.expand_path\("spring", __dir__\)/
 
   if (index = lines.index { |line| line =~ spring_pattern })
-    remove_gem :spring
+    CableReady::Installer.remove_gem :spring
 
     bin_spring = Rails.root.join("bin/spring")
     if bin_spring.exist?
@@ -33,7 +33,7 @@ if proceed
     bin_rails = Rails.root.join("bin/rails")
     bin_rails_content = bin_rails.readlines
     if (index = bin_rails_content.index { |line| line =~ bin_rails_pattern })
-      backup(bin_rails) do
+      CableReady::Installer.backup(bin_rails) do
         bin_rails_content[index] = "# #{bin_rails_content[index]}"
         bin_rails.write bin_rails_content.join
       end
@@ -45,10 +45,10 @@ if proceed
   end
 
   if lines.index { |line| line =~ spring_watcher_pattern }
-    remove_gem "spring-watcher-listen"
+    CableReady::Installer.remove_gem "spring-watcher-listen"
   end
 else
   say "⏩ Skipping."
 end
 
-complete_step :spring
+CableReady::Installer.complete_step :spring

--- a/lib/install/updatable.rb
+++ b/lib/install/updatable.rb
@@ -2,18 +2,18 @@
 
 require "cable_ready/installer"
 
-if application_record_path.exist?
-  lines = application_record_path.readlines
+if CableReady::Installer.application_record_path.exist?
+  lines = CableReady::Installer.application_record_path.readlines
 
   if !lines.index { |line| line =~ /^\s*include CableReady::Updatable/ }
-    proceed = if options.key? "updatable"
-      options["updatable"]
+    proceed = if CableReady::Installer.options.key? "updatable"
+      CableReady::Installer.options["updatable"]
     else
       !no?("✨ Include CableReady::Updatable in Active Record model classes? (Y/n)")
     end
 
     unless proceed
-      complete_step :updatable
+      CableReady::Installer.complete_step :updatable
 
       puts "⏩ Skipping."
       return
@@ -21,7 +21,7 @@ if application_record_path.exist?
 
     index = lines.index { |line| line.include?("class ApplicationRecord < ActiveRecord::Base") }
     lines.insert index + 1, "  include CableReady::Updatable\n"
-    application_record_path.write lines.join
+    CableReady::Installer.application_record_path.write lines.join
 
     say "✅ included CableReady::Updatable in ApplicationRecord"
   else
@@ -31,4 +31,4 @@ else
   say "⏩ ApplicationRecord doesn't exist. Skipping."
 end
 
-complete_step :updatable
+CableReady::Installer.complete_step :updatable

--- a/lib/install/vite.rb
+++ b/lib/install/vite.rb
@@ -2,30 +2,30 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 # verify that all critical dependencies are up to date; if not, queue for later
-lines = package_json.readlines
+lines = CableReady::Installer.package_json.readlines
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus["']:/ }
-  add_package "@hotwired/stimulus@^3.2"
+  CableReady::Installer.add_package "@hotwired/stimulus@^3.2"
 else
   say "⏩ @hotwired/stimulus npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']stimulus-vite-helpers["']: ["']\^3["']/ }
-  add_package "stimulus-vite-helpers@^3"
+  CableReady::Installer.add_package "stimulus-vite-helpers@^3"
 else
   say "⏩ @stimulus-vite-helpers npm package is already present. Skipping."
 end
 
 step_path = "/app/javascript/controllers/"
-application_js_src = fetch(step_path, "application.js.tt")
-application_js_path = controllers_path / "application.js"
-index_src = fetch(step_path, "index.js.vite.tt")
-index_path = controllers_path / "index.js"
+application_js_src = CableReady::Installer.fetch(step_path, "application.js.tt")
+application_js_path = CableReady::Installer.controllers_path / "application.js"
+index_src = CableReady::Installer.fetch(step_path, "index.js.vite.tt")
+index_path = CableReady::Installer.controllers_path / "index.js"
 
 # create entrypoint/controllers, as well as the index, application and application_controller
-empty_directory controllers_path unless controllers_path.exist?
+empty_directory CableReady::Installer.controllers_path unless CableReady::Installer.controllers_path.exist?
 
 copy_file(application_js_src, application_js_path) unless application_js_path.exist?
 copy_file(index_src, index_path) unless index_path.exist?
@@ -34,33 +34,33 @@ controllers_pattern = /import ['"](\.\.\/)?controllers['"]/
 controllers_commented_pattern = /\s*\/\/\s*#{controllers_pattern}/
 prefix = "..\/" # standard:disable Style/RedundantStringEscape
 
-if pack.match?(controllers_pattern)
-  if pack.match?(controllers_commented_pattern)
-    proceed = if options.key? "uncomment"
-      options["uncomment"]
+if CableReady::Installer.pack.match?(controllers_pattern)
+  if CableReady::Installer.pack.match?(controllers_commented_pattern)
+    proceed = if CableReady::Installer.options.key? "uncomment"
+      CableReady::Installer.options["uncomment"]
     else
       !no?("✨ Do you want to import your Stimulus controllers in application.js? (Y/n)")
     end
 
     if proceed
       # uncomment_lines only works with Ruby comments 🙄
-      lines = pack_path.readlines
+      lines = CableReady::Installer.pack_path.readlines
       matches = lines.select { |line| line =~ controllers_commented_pattern }
       lines[lines.index(matches.last).to_i] = "import \"#{prefix}controllers\"\n"
-      pack_path.write lines.join
-      say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+      CableReady::Installer.pack_path.write lines.join
+      say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
     else
       say "🤷 your Stimulus controllers are not being imported in your application.js. We trust that you have a reason for this."
     end
   else
-    say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+    say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, "import \"#{prefix}controllers\"\n"
-  pack_path.write lines.join
-  say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+  CableReady::Installer.pack_path.write lines.join
+  say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
 end
 
-complete_step :vite
+CableReady::Installer.complete_step :vite

--- a/lib/install/webpacker.rb
+++ b/lib/install/webpacker.rb
@@ -2,54 +2,54 @@
 
 require "cable_ready/installer"
 
-return if pack_path_missing?
+return if CableReady::Installer.pack_path_missing?
 
 # verify that all critical dependencies are up to date; if not, queue for later
-lines = package_json.readlines
+lines = CableReady::Installer.package_json.readlines
 if !lines.index { |line| line =~ /^\s*["']webpack["']: ["']\^4.46.0["']/ }
-  add_package "webpack@^4.46.0"
+  CableReady::Installer.add_package "webpack@^4.46.0"
 else
   say "⏩ webpack npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']webpack-cli["']: ["']\^3.3.12["']/ }
-  add_package "webpack-cli@^3.3.12"
+  CableReady::Installer.add_package "webpack-cli@^3.3.12"
 else
   say "⏩ webpack-cli npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']@rails\/webpacker["']: ["']\^5.4.3["']/ }
-  add_package "@rails/webpacker@^5.4.3"
+  CableReady::Installer.add_package "@rails/webpacker@^5.4.3"
 else
   say "⏩ @rails/webpacker npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus["']:/ }
-  add_package "@hotwired/stimulus@^3.2"
+  CableReady::Installer.add_package "@hotwired/stimulus@^3.2"
 else
   say "⏩ @hotwired/stimulus npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']@hotwired\/stimulus-webpack-helpers["']: ["']\^1.0.1["']/ }
-  add_package "@hotwired/stimulus-webpack-helpers@^1.0.1"
+  CableReady::Installer.add_package "@hotwired/stimulus-webpack-helpers@^1.0.1"
 else
   say "⏩ @hotwired/stimulus-webpack-helpers npm package is already present. Skipping."
 end
 
 if !lines.index { |line| line =~ /^\s*["']webpack-dev-server["']: ["']\^3.11.3["']/ }
-  add_dev_package "webpack-dev-server@^3.11.3"
+  CableReady::Installer.add_dev_package "webpack-dev-server@^3.11.3"
 else
   say "⏩ @webpack-dev-server is already present. Skipping."
 end
 
 step_path = "/app/javascript/controllers/"
-application_js_src = fetch(step_path, "application.js.tt")
-application_js_path = controllers_path / "application.js"
-index_src = fetch(step_path, "index.js.webpacker.tt")
-index_path = controllers_path / "index.js"
+application_js_src = CableReady::Installer.fetch(step_path, "application.js.tt")
+application_js_path = CableReady::Installer.controllers_path / "application.js"
+index_src = CableReady::Installer.fetch(step_path, "index.js.webpacker.tt")
+index_path = CableReady::Installer.controllers_path / "index.js"
 
 # create entrypoint/controllers, as well as the index, application and application_controller
-empty_directory controllers_path unless controllers_path.exist?
+empty_directory CableReady::Installer.controllers_path unless CableReady::Installer.controllers_path.exist?
 
 # webpacker 5.4 did not colloquially feature a controllers/application.js file
 copy_file(application_js_src, application_js_path) unless application_js_path.exist?
@@ -68,26 +68,26 @@ if pack.match?(controllers_pattern)
 
     if proceed
       # uncomment_lines only works with Ruby comments 🙄
-      lines = pack_path.readlines
+      lines = CableReady::Installer.pack_path.readlines
       matches = lines.select { |line| line =~ controllers_commented_pattern }
       lines[lines.index(matches.last).to_i] = "import \"controllers\"\n"
-      pack_path.write lines.join
-      say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+      CableReady::Installer.pack_path.write lines.join
+      say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
     else
       say "🤷 your Stimulus controllers are not being imported in your application.js. We trust that you have a reason for this."
     end
   else
-    say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+    say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
   end
 else
-  lines = pack_path.readlines
+  lines = CableReady::Installer.pack_path.readlines
   matches = lines.select { |line| line =~ /^import / }
   lines.insert lines.index(matches.last).to_i + 1, "import \"controllers\"\n"
-  pack_path.write lines.join
-  say "✅ Stimulus controllers imported in #{friendly_pack_path}"
+  CableReady::Installer.pack_path.write lines.join
+  say "✅ Stimulus controllers imported in #{CableReady::Installer.friendly_pack_path}"
 end
 
 # ensure webpacker is installed in the Gemfile
-add_gem "webpacker@5.4.3"
+CableReady::Installer.add_gem "webpacker@5.4.3"
 
-complete_step :webpacker
+CableReady::Installer.complete_step :webpacker

--- a/lib/install/yarn.rb
+++ b/lib/install/yarn.rb
@@ -2,18 +2,18 @@
 
 require "cable_ready/installer"
 
-if !package_json.exist?
+if !CableReady::Installer.package_json.exist?
   say "⏩ No package.json file found. Skipping."
 
   return
 end
 
 # run yarn install only when packages are waiting to be added or removed
-add = package_list.exist? ? package_list.readlines.map(&:chomp) : []
-dev = dev_package_list.exist? ? dev_package_list.readlines.map(&:chomp) : []
-drop = drop_package_list.exist? ? drop_package_list.readlines.map(&:chomp) : []
+add = CableReady::Installer.package_list.exist? ? CableReady::Installer.package_list.readlines.map(&:chomp) : []
+dev = CableReady::Installer.dev_package_list.exist? ? CableReady::Installer.dev_package_list.readlines.map(&:chomp) : []
+drop = CableReady::Installer.drop_package_list.exist? ? CableReady::Installer.drop_package_list.readlines.map(&:chomp) : []
 
-json = JSON.parse(package_json.read)
+json = JSON.parse(CableReady::Installer.package_json.read)
 
 if add.present? || dev.present? || drop.present?
 
@@ -36,7 +36,7 @@ if add.present? || dev.present? || drop.present?
     json["devDependencies"].delete(package)
   end
 
-  package_json.write JSON.pretty_generate(json)
+  CableReady::Installer.package_json.write JSON.pretty_generate(json)
 
   system "yarn install --silent"
 else
@@ -44,13 +44,13 @@ else
 
 end
 
-if bundler == "esbuild" && json["scripts"]["build"] != "node esbuild.config.mjs"
+if CableReady::Installer.bundler == "esbuild" && json["scripts"]["build"] != "node esbuild.config.mjs"
   json["scripts"]["build:default"] = json["scripts"]["build"]
   json["scripts"]["build"] = "node esbuild.config.mjs"
-  package_json.write JSON.pretty_generate(json)
+  CableReady::Installer.package_json.write JSON.pretty_generate(json)
   say "✅ Your build script has been updated to use esbuild.config.mjs"
 else
   say "⏩ Your build script is already setup. Skipping."
 end
 
-complete_step :yarn
+CableReady::Installer.complete_step :yarn


### PR DESCRIPTION
# Type of PR

Enhancement

## Description

This pull request isolates the methods defined `lib/cable_ready/installer.rb` into a `CableReady::Installer` constant so they don't pollute the global namespace if the file is required.

## Why should this be added

Exposing all the methods from the installer in the global namespace could lead to issues down the road. Methods like `options` are likely to be overridden.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Checks (StandardRB & Prettier-Standard) are passing
