### PR TITLE
Observers clear references

### DIFF
--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -27,7 +27,7 @@ module CableReady
         .select { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
           channels.each { |channel| @channels[channel.identifier].broadcast(clear: clear) }
-          channels.each { |channel| @channels.except!(channel.identifier) if clear }
+          channels.each { |channel| clear_channel(channel)  if clear }
         end
     end
 
@@ -37,8 +37,16 @@ module CableReady
         .reject { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
           channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear: clear) }
-          channels.each { |channel| @channels.except!(channel.identifier) if clear }
+          channels.each { |channel| clear_channel(channel)  if clear }
         end
+    end
+
+    private
+
+    def clear_channel(channel)
+      @channels.except!(channel.identifier)
+      observer = CableReady.config.observers.find { |o| o.try(:identifier) == channel.identifier}
+      CableReady.config.delete_observer(observer) if observer
     end
   end
 end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -45,7 +45,7 @@ module CableReady
 
     def clear_channel(channel)
       @channels.except!(channel.identifier)
-      observer = CableReady.config.observers.find { |o| o.try(:identifier) == channel.identifier}
+      observer = CableReady.config.observers.find { |o| o.try(:identifier) == channel.identifier }
       CableReady.config.delete_observer(observer) if observer
     end
   end

--- a/lib/cable_ready/channels.rb
+++ b/lib/cable_ready/channels.rb
@@ -27,7 +27,7 @@ module CableReady
         .select { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
           channels.each { |channel| @channels[channel.identifier].broadcast(clear: clear) }
-          channels.each { |channel| clear_channel(channel)  if clear }
+          channels.each { |channel| clear_channel(channel) if clear }
         end
     end
 
@@ -37,7 +37,7 @@ module CableReady
         .reject { |channel| channel.identifier.is_a?(String) }
         .tap do |channels|
           channels.each { |channel| @channels[channel.identifier].broadcast_to(model, clear: clear) }
-          channels.each { |channel| clear_channel(channel)  if clear }
+          channels.each { |channel| clear_channel(channel) if clear }
         end
     end
 


### PR DESCRIPTION
# Type of PR
Bug fix

## Description

Process level (`CableReady::Config` -  `@observer_peers`) channel clearing.

Fixes #297 

## Why should this be added

Possible memory leak fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
