### PR TITLE
Unsubscribe from the channel when UpdatesForElement disconnects

### DIFF
--- a/javascript/elements/updates_for_element.js
+++ b/javascript/elements/updates_for_element.js
@@ -64,6 +64,7 @@ export default class UpdatesForElement extends SubscribingElement {
   }
 
   disconnectedCallback () {
+    super.disconnectedCallback()
     if (this.observeAppearance) {
       this.appearanceObserver.stop()
     }


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)
Bug fix

## Description
Unsubscribe from the channel by calling superclass's (SubscribingElement) disconnectedCallback.

## Why should this be added
Fix repeated subscribe messages after a morph.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Checks (StandardRB & Prettier-Standard) are passing
