### PR TITLE
Apply safe navigation when resolving optional belongs_to resource

### DIFF
--- a/app/models/concerns/cable_ready/updatable/collections_registry.rb
+++ b/app/models/concerns/cable_ready/updatable/collections_registry.rb
@@ -52,7 +52,7 @@ module CableReady
 
         resource = model
         resource = resource.send(collection.through_association.underscore) if collection.through_association
-        resource.send(collection.inverse_association.underscore)
+        resource&.send(collection.inverse_association.underscore)
       end
     end
   end


### PR DESCRIPTION
# Bug fix

## Description

Handle resolving a dangling (`optional: true`) belongs_to inverse association gracefully
